### PR TITLE
Move wire declarations before they're first used

### DIFF
--- a/verilog/rtl/mgmt_core.v
+++ b/verilog/rtl/mgmt_core.v
@@ -79,6 +79,16 @@ module mgmt_core #(
     	wire ext_reset;
 	wire hk_connect;
 
+	// JTAG (to be implemented)
+	wire jtag_out = 1'b0;
+	wire jtag_outenb = 1'b1;
+
+	// Housekeeping SPI vectors
+	wire [4:0]  spi_pll_div;
+	wire [2:0]  spi_pll_sel;
+	wire [2:0]  spi_pll90_sel;
+	wire [25:0] spi_pll_trim;
+
 	caravel_clocking clocking(
 	`ifdef LVS
 		.vdd1v8(vdd1v8),
@@ -213,16 +223,6 @@ module mgmt_core #(
 		.dco(spi_pll_dco_ena),
 		.ext_trim(spi_pll_trim)
     	);
-
-	// JTAG (to be implemented)
-	wire jtag_out = 1'b0;
-	wire jtag_outenb = 1'b1;
-
-	// Housekeeping SPI vectors
-	wire [4:0]  spi_pll_div;
-	wire [2:0]  spi_pll_sel;
-	wire [2:0]  spi_pll90_sel;
-	wire [25:0] spi_pll_trim;
 
 	// Housekeeping SPI (SPI slave module)
 	housekeeping_spi housekeeping (


### PR DESCRIPTION
Otherwise, I was getting

```
../../../../rtl/mgmt_core.v:222: error: duplicate declaration for net or variable 'spi_pll_div' in 'mgmt_core'.
../../../../rtl/mgmt_core.v:223: error: duplicate declaration for net or variable 'spi_pll_sel' in 'mgmt_core'.
../../../../rtl/mgmt_core.v:224: error: duplicate declaration for net or variable 'spi_pll90_sel' in 'mgmt_core'.
../../../../rtl/mgmt_core.v:225: error: duplicate declaration for net or variable 'spi_pll_trim' in 'mgmt_core'.
```

with `Icarus Verilog version 10.3 (stable) (v10_3)`, since it infers an implicit declaration of those wires where they were first referenced.