### PR TITLE
Some modifications related to the use of params

### DIFF
--- a/verilog/rtl/caravel.v
+++ b/verilog/rtl/caravel.v
@@ -12,13 +12,10 @@
 
 `timescale 1 ns / 1 ps
 
-`define USE_OPENRAM
 `define USE_POWER_PINS
 `define UNIT_DELAY #1
 
-`define MPRJ_IO_PADS 38
-`define MPRJ_PWR_PADS 4		/* vdda1, vccd1, vdda2, vccd2 */
-
+`include "defines.v"
 `include "pads.v"
 
 /* NOTE: Need to pass the PDK root directory to iverilog with option -I */
@@ -316,10 +313,7 @@ module caravel (
 	wire	    mprj_vdd_pwrgood;
 	wire	    mprj2_vdd_pwrgood;
 
-    mgmt_core #(
-	.MPRJ_IO_PADS(`MPRJ_IO_PADS),
-	.MPRJ_PWR_PADS(`MPRJ_PWR_PADS)
-    ) soc (
+    mgmt_core soc (
 	`ifdef LVS
 		.vdd(vccd),
 		.vss(vssa),
@@ -434,10 +428,7 @@ module caravel (
 	/* Wrapper module around the user project 	*/
 	/*----------------------------------------------*/
 
-	user_project_wrapper #(
-	    .IO_PADS(`MPRJ_IO_PADS),
-	    .PWR_PADS(`MPRJ_PWR_PADS)
-	) mprj ( 
+	user_project_wrapper mprj ( 
 		.vdda1(vdda1),	// User area 1 3.3V power
 		.vdda2(vdda2),	// User area 2 3.3V power
 		.vssa1(vssa1),	// User area 1 analog ground

--- a/verilog/rtl/defines.v
+++ b/verilog/rtl/defines.v
@@ -1,0 +1,11 @@
+// Global parameters
+
+`define MPRJ_IO_PADS 38
+`define MPRJ_PWR_PADS 4		/* vdda1, vccd1, vdda2, vccd2 */
+
+// Size of soc_mem_synth
+`define MEM_SYNTH_WORDS 1024
+
+// Type and size of soc_mem
+`define USE_OPENRAM
+`define MEM_WORDS 256

--- a/verilog/rtl/mem_synth_wb.v
+++ b/verilog/rtl/mem_synth_wb.v
@@ -1,6 +1,4 @@
-module mem_synth_wb #(
-   parameter integer MEM_WORDS = 1024
-)( 
+module mem_synth_wb ( 
     input wb_clk_i,
     input wb_rst_i,
 
@@ -37,9 +35,7 @@ module mem_synth_wb #(
         end
     end
 
-    soc_mem_synth # (
-        .MEM_WORDS(MEM_WORDS)
-    ) mem (
+    soc_mem_synth mem (
         .clk(wb_clk_i),
         .ena(valid),
         .wen(wen),
@@ -50,9 +46,7 @@ module mem_synth_wb #(
 
 endmodule
 
-module soc_mem_synth #(
-    parameter integer MEM_WORDS = 2048
-)(
+module soc_mem_synth (
     input clk,
     input ena,
     input [3:0] wen,
@@ -62,7 +56,7 @@ module soc_mem_synth #(
 );
 
     reg [31:0] rdata;
-    reg [31:0] mem [0:MEM_WORDS-1];
+    reg [31:0] mem [0:`MEM_SYNTH_WORDS-1];
 
     always @(posedge clk) begin
         if (ena == 1'b1) begin

--- a/verilog/rtl/mem_wb.v
+++ b/verilog/rtl/mem_wb.v
@@ -1,6 +1,4 @@
-module mem_wb # (
-    parameter integer MEM_WORDS = 256
-) (
+module mem_wb (
     input wb_clk_i,
     input wb_rst_i,
 
@@ -50,7 +48,11 @@ module mem_wb # (
 
 `endif
 
-    soc_mem mem(
+    soc_mem
+`ifndef USE_OPENRAM
+    #(.WORDS(`MEM_WORDS))
+`endif
+     mem (
         .clk(wb_clk_i),
         .ena(valid),
         .wen(wen),

--- a/verilog/rtl/mgmt_core.v
+++ b/verilog/rtl/mgmt_core.v
@@ -1,7 +1,4 @@
-module mgmt_core #(
-	parameter MPRJ_IO_PADS = 32,
-	parameter MPRJ_PWR_PADS = 32
-) (
+module mgmt_core (
 `ifdef LVS
 	inout vdd1v8,	   
 	inout vss,
@@ -43,9 +40,9 @@ module mgmt_core #(
 	output jtag_out,
 	output jtag_outenb,
 	// User Project Control Signals
-	input [MPRJ_IO_PADS-1:0] mgmt_in_data,
-	output [MPRJ_IO_PADS-1:0] mgmt_out_data,
-	output [MPRJ_PWR_PADS-1:0] pwr_ctrl_out,
+	input [`MPRJ_IO_PADS-1:0] mgmt_in_data,
+	output [`MPRJ_IO_PADS-1:0] mgmt_out_data,
+	output [`MPRJ_PWR_PADS-1:0] pwr_ctrl_out,
 	input mprj_vcc_pwrgood,
 	input mprj2_vcc_pwrgood,
 	input mprj_vdd_pwrgood,
@@ -139,11 +136,7 @@ module mgmt_core #(
 	// the pad.  All others have OEB controlled by the configuration bit
 	// in the control block.
 
-	mgmt_soc #(
-	    .MPRJ_IO_PADS(MPRJ_IO_PADS),
-	    .MPRJ_PWR_PADS(MPRJ_PWR_PADS)
-	) soc (
-	
+	mgmt_soc soc (
     	    `ifdef LVS
         	.vdd1v8(vdd1v8),
         	.vss(vss),

--- a/verilog/rtl/mgmt_soc.v
+++ b/verilog/rtl/mgmt_soc.v
@@ -44,10 +44,7 @@
 `include "convert_gpio_sigs.v"
 `include "mem_synth_wb.v"
 
-module mgmt_soc #(
-    parameter MPRJ_IO_PADS = 32,
-    parameter MPRJ_PWR_PADS = 32
-) (
+module mgmt_soc (
 `ifdef LVS
     inout vdd1v8,	    /* 1.8V domain */
     inout vss,
@@ -81,9 +78,9 @@ module mgmt_soc #(
     output mprj_io_loader_data,
 
     // User Project pad data (when management SoC controls the pad)
-    input [MPRJ_IO_PADS-1:0] mgmt_in_data,
-    output [MPRJ_IO_PADS-1:0] mgmt_out_data,
-    output [MPRJ_PWR_PADS-1:0] pwr_ctrl_out,
+    input [`MPRJ_IO_PADS-1:0] mgmt_in_data,
+    output [`MPRJ_IO_PADS-1:0] mgmt_out_data,
+    output [`MPRJ_PWR_PADS-1:0] pwr_ctrl_out,
 
     // IRQ
     input  irq_spi,		// IRQ from standalone SPI
@@ -144,9 +141,7 @@ module mgmt_soc #(
     output [31:0] mprj_dat_o
 );
     /* Memory reverted back to 256 words while memory has to be synthesized */
-    parameter integer MEM_WORDS = 256;
-    parameter integer MEM_SYNTH_WORDS = 1024;
-    parameter [31:0] STACKADDR = (4*(MEM_WORDS + MEM_SYNTH_WORDS));       // end of memory
+    parameter [31:0] STACKADDR = (4*(`MEM_WORDS + `MEM_SYNTH_WORDS));       // end of memory
     parameter [31:0] PROGADDR_RESET = 32'h 1000_0000; 
     parameter [31:0] PROGADDR_IRQ   = 32'h 0000_0000;
 
@@ -660,13 +655,13 @@ module mgmt_soc #(
     wire mprj_ctrl_stb_i;
     wire mprj_ctrl_ack_o;
     wire [31:0] mprj_ctrl_dat_o;
-    wire [MPRJ_IO_PADS-1:0] mgmt_out_pre;
+    wire [`MPRJ_IO_PADS-1:0] mgmt_out_pre;
 
     // Bits assigned to specific functions as outputs prevent the
     // mprj GPIO-as-output from applying data when that function
     // is active
 
-    assign mgmt_out_data[MPRJ_IO_PADS-1:16] = mgmt_out_pre[MPRJ_IO_PADS-1:16];
+    assign mgmt_out_data[`MPRJ_IO_PADS-1:16] = mgmt_out_pre[`MPRJ_IO_PADS-1:16];
 
     // Routing of output monitors (PLL, trap, clk1, clk2)
     assign mgmt_out_data[15] = clk2_output_dest ? user_clk : mgmt_out_pre[15];
@@ -678,9 +673,7 @@ module mgmt_soc #(
     assign mgmt_out_data[5:0] = mgmt_out_pre[5:0];
 
     mprj_ctrl_wb #(
-        .BASE_ADR(MPRJ_CTRL_ADR),
-        .IO_PADS(MPRJ_IO_PADS),
-        .PWR_PADS(MPRJ_PWR_PADS)
+        .BASE_ADR(MPRJ_CTRL_ADR)
     ) mprj_ctrl (
         .wb_clk_i(wb_clk_i),
         .wb_rst_i(wb_rst_i),
@@ -709,9 +702,7 @@ module mgmt_soc #(
     wire mem_ack_o;
     wire [31:0] mem_dat_o;
 
-    mem_wb #(
-        .MEM_WORDS(MEM_WORDS)
-    ) soc_mem (
+    mem_wb soc_mem (
         .wb_clk_i(wb_clk_i),
         .wb_rst_i(wb_rst_i),
 
@@ -731,9 +722,7 @@ module mgmt_soc #(
     wire mem_synth_ack_o;
     wire [31:0] mem_synth_dat_o;
 
-    mem_synth_wb #(
-        .MEM_WORDS(MEM_SYNTH_WORDS)
-    ) soc_mem_synth (
+    mem_synth_wb soc_mem_synth (
         .wb_clk_i(wb_clk_i),
         .wb_rst_i(wb_rst_i),
         .wb_adr_i(cpu_adr_o), 

--- a/verilog/rtl/user_proj_example.v
+++ b/verilog/rtl/user_proj_example.v
@@ -20,8 +20,6 @@
  */
 
 module user_proj_example #(
-    parameter IO_PADS = 38,
-    parameter PWR_PADS = 4,
     parameter BITS = 32
 )(
     inout vdda1,	// User area 1 3.3V supply
@@ -51,16 +49,16 @@ module user_proj_example #(
     input  [127:0] la_oen,
 
     // IOs
-    input  [IO_PADS-1:0] io_in,
-    output [IO_PADS-1:0] io_out,
-    output [IO_PADS-1:0] io_oeb
+    input  [`MPRJ_IO_PADS-1:0] io_in,
+    output [`MPRJ_IO_PADS-1:0] io_out,
+    output [`MPRJ_IO_PADS-1:0] io_oeb
 );
     wire clk;
     wire rst;
 
-    wire [IO_PADS-1:0] io_in;
-    wire [IO_PADS-1:0] io_out;
-    wire [IO_PADS-1:0] io_oeb;
+    wire [`MPRJ_IO_PADS-1:0] io_in;
+    wire [`MPRJ_IO_PADS-1:0] io_out;
+    wire [`MPRJ_IO_PADS-1:0] io_oeb;
 
     wire [31:0] rdata; 
     wire [31:0] wdata;
@@ -78,7 +76,7 @@ module user_proj_example #(
 
     // IO
     assign io_out = count;
-    assign io_oeb = {(IO_PADS-1){rst}};
+    assign io_oeb = {(`MPRJ_IO_PADS-1){rst}};
 
     // LA
     assign la_data_out = {{(127-BITS){1'b0}}, count};

--- a/verilog/rtl/user_project_wrapper.v
+++ b/verilog/rtl/user_project_wrapper.v
@@ -14,8 +14,6 @@
  */
 
 module user_project_wrapper #(
-    parameter IO_PADS = 38,
-    parameter PWR_PADS = 4,
     parameter BITS = 32
 )(
     inout vdda1,	// User area 1 3.3V supply
@@ -45,9 +43,9 @@ module user_project_wrapper #(
     input  [127:0] la_oen,
 
     // IOs
-    input  [IO_PADS-1:0] io_in,
-    output [IO_PADS-1:0] io_out,
-    output [IO_PADS-1:0] io_oeb,
+    input  [`MPRJ_IO_PADS-1:0] io_in,
+    output [`MPRJ_IO_PADS-1:0] io_out,
+    output [`MPRJ_IO_PADS-1:0] io_oeb,
 
     // Independent clock (on independent integer divider)
     input   user_clock2
@@ -57,10 +55,7 @@ module user_project_wrapper #(
     /* User project is instantiated  here   */
     /*--------------------------------------*/
 
-    user_proj_example #(
-	.IO_PADS(IO_PADS),
-	.PWR_PADS(PWR_PADS)
-    ) mprj ( 
+    user_proj_example mprj (
 	.vdda1(vdda1),	// User area 1 3.3V power
 	.vdda2(vdda2),	// User area 2 3.3V power
 	.vssa1(vssa1),	// User area 1 analog ground
@@ -75,7 +70,7 @@ module user_project_wrapper #(
     	.wb_clk_i(wb_clk_i),
     	.wb_rst_i(wb_rst_i),
 
-	// MGMT SoC Wishbone Slave 
+	// MGMT SoC Wishbone Slave
 
 	.wbs_cyc_i(wbs_cyc_i),
 	.wbs_stb_i(wbs_stb_i),


### PR DESCRIPTION
- chip_io and mprj_io: switch to a parameter defaulting at 38
- mem_wb: size the synthesized memory using MEM_WORDS

---------------------------------------------------------------------------------------------
An alternative would be to create a "defs.v" to be included in other files.