### PR TITLE
Fix for the synthesis warnings about iomem_rdata

### DIFF
--- a/verilog/rtl/mprj_ctrl.v
+++ b/verilog/rtl/mprj_ctrl.v
@@ -225,7 +225,6 @@ module mprj_ctrl #(
 	    xfer_ctrl <= 0;
             pwr_ctrl_out <= 0;
 	end else begin
-	    iomem_ready <= 0;
 	    if (iomem_valid && !iomem_ready && iomem_addr[31:8] == BASE_ADR[31:8]) begin
 		if (xfer_sel) begin
 		    if (iomem_wstrb[0]) xfer_ctrl <= iomem_wdata[0];


### PR DESCRIPTION
- Works by assigning iomem_rdata_pre inside one always block with a
  generate block outside, providing the needed signals
- TODO: handle some scattered conflict warnings here and there in the
  synthesis log about other signals

------------------------------------------------------
Probably can get rid of the OR gates in `end else if (|io_data_sel) begin`, but I assume that yosys is able to optimize them out by itself.