### PR TITLE
user_proj_example.v: Fix wbs_ack_o wiring

### DIFF
--- a/verilog/rtl/user_proj_example.v
+++ b/verilog/rtl/user_proj_example.v
@@ -91,7 +91,7 @@ module user_proj_example #(
     ) counter(
         .clk(clk),
         .reset(rst),
-        .ready(wbs_ack_i),
+        .ready(wbs_ack_o),
         .valid(valid),
         .rdata(rdata),
         .wdata(wbs_dat_i),


### PR DESCRIPTION
`wbs_ack_i` here seems to be a typo.

(I've not simulated this as I've read that certain IO modules need to be released first)