### PR TITLE
consider test debug be use only dff in linkerscript since test overwrites dff2 

### DIFF
--- a/verilog/dv/cocotb/tests/debug/debug.py
+++ b/verilog/dv/cocotb/tests/debug/debug.py
@@ -35,7 +35,7 @@ async def debug(dut):
     # caravelEnv.drive_gpio_in((0,0),1) # IO[0] affects the uart selecting btw system and debug
     cocotb.log.info(f"[TEST] Start debug test")  
     # send random data to address 30'h00400024 and expect to recieve the same data back it back
-    dff_address = random.randint(0x00000400, 0x00000600)
+    dff_address = random.randint(0x00000400, 0x00000600) & 0xFFFFFFFC
     data = random.getrandbits(32)
     address = dff_address >>2 # address has to be shifted
     # data = 0xFFFFFFF0

--- a/verilog/dv/cocotb/verify_cocotb.py
+++ b/verilog/dv/cocotb/verify_cocotb.py
@@ -163,7 +163,7 @@ class RunTest:
 
     def hex_generate(self):
         tests_use_dff2 = ["mem_dff"]
-        tests_use_dff = ["mem_dff2"]
+        tests_use_dff = ["mem_dff2","debug"]
         #open docker 
         test_path =self.test_path()
         self.cd_make()


### PR DESCRIPTION
consider test debug be use only dff in linkerscript since test writes to the dff2 ram and align the addresses generated