### PR TITLE
Fix errors in caravan top level RTL

### DIFF
--- a/manifest
+++ b/manifest
@@ -5,7 +5,7 @@
 5f8e2d6670ce912bc209201d23430f62730e2627  verilog/rtl/__user_project_la_example.v
 cc82a78753f5f5d0a1519bd81adbcff8a4296d91  verilog/rtl/__user_project_wrapper.v
 3c8c04f53b2848dc46132cda82c614e06e56571b  verilog/rtl/buff_flash_clkrst.v
-25d11686a71ef04dd6768a28c5a5b4183f856560  verilog/rtl/caravan.v
+a84d93fc4d177c1cf728a13f72720d4abb90b001  verilog/rtl/caravan.v
 06e92151b5928e3f28e30a5cde76f7dd6530ed91  verilog/rtl/caravan_netlists.v
 a3d12a2d2d3596800bec47d1266dce2399a2fcc6  verilog/rtl/caravan_openframe.v
 b532b4c6315c29fd19fe38ac221b6fc41e6f5ecb  verilog/rtl/caravan_power_routing.v


### PR DESCRIPTION
This fixes errors in the top level RTL of caravan that failed to hook up the buffers through the SoC correctly.  Corrections have been tested with the caravan testbench that was checked into the caravel_mgmt_soc_litex repository caravel_redesign branch.  Note that this fix was made relative to the caravan_redesign branch of the caravel repository.