### PR TITLE
cocotb - updates related to enable simulating caravan using iverilog

### DIFF
--- a/manifest
+++ b/manifest
@@ -1,6 +1,6 @@
 535d0592c0b1349489b6b86fd5449f9d1d81482e  verilog/rtl/__uprj_analog_netlists.v
 87735eb5981740ca4d4b48e6b0321c8bb0023800  verilog/rtl/__uprj_netlists.v
-684085713662e37a26f9f981d35be7c6c7ff6e9a  verilog/rtl/__user_analog_project_wrapper.v
+cf40562ae6508f3dc5e81420e31f7b5886dc3c8f  verilog/rtl/__user_analog_project_wrapper.v
 79cdb50a7dd60f69b63c0b6440b0dea35386387d  verilog/rtl/__user_project_gpio_example.v
 5f8e2d6670ce912bc209201d23430f62730e2627  verilog/rtl/__user_project_la_example.v
 cc82a78753f5f5d0a1519bd81adbcff8a4296d91  verilog/rtl/__user_project_wrapper.v

--- a/verilog/dv/cocotb/caravel_top.sv
+++ b/verilog/dv/cocotb/caravel_top.sv
@@ -74,8 +74,11 @@ end
     wire flash_io1_tb;
 
 
-	
+`ifdef CARAVAN
+caravan uut (
+`else
 caravel uut (
+`endif
 		.vddio	  (vddio_tb),
 		.vddio_2  (vddio_2_tb),		
 		.vssio	  (vssio_tb),

--- a/verilog/dv/cocotb/tests.json
+++ b/verilog/dv/cocotb/tests.json
@@ -4,8 +4,8 @@
         "_comment1" :"GL regressions run this test in gatelevel, GL_SDF regression run this test with SDF included"
         ,"gpio_all_i" :{"level":0, 
             "SW":true,
-            "RTL":["r_rtl","setup","gpio_rtl","push","push_gl","nightly","weekly","tape_out"],
-            "GL":["r_gl","push_gl","gpio_gl","nightly","weekly","tape_out"],
+            "RTL":["r_rtl","r_caravan_rtl","setup","gpio_rtl","push","push_gl","nightly","weekly","tape_out"],
+            "GL":["r_gl","r_caravan_gl","push_gl","gpio_gl","nightly","weekly","tape_out"],
             "GL_SDF":["r_sdf","weekly","tape_out"],
             "description":"configure all gpios as mgmt input using automatic approach firmware and check them"}
 
@@ -30,15 +30,15 @@
         
         ,"gpio_all_i_user" :{"level":0, 
             "SW":true,
-            "RTL":["r_rtl","setup","gpio_rtl","push","push_gl","nightly","weekly","tape_out"],
-            "GL":["r_gl","push_gl","gpio_gl","nightly","weekly","tape_out"],
+            "RTL":["r_rtl","setup","r_caravan_rtl","gpio_rtl","push","push_gl","nightly","weekly","tape_out"],
+            "GL":["r_gl","r_caravan_gl","push_gl","gpio_gl","nightly","weekly","tape_out"],
             "GL_SDF":["r_sdf","weekly","tape_out"],
             "description":"configure all gpios as user input using automatic approach firmware and check them"}
 
         ,"gpio_all_i_pu" :{"level":0, 
             "SW":true,
-            "RTL":["r_rtl","setup","gpio_rtl","push","push_gl","nightly","weekly","tape_out"],
-            "GL":["r_gl","push_gl","gpio_gl","nightly","weekly","tape_out"],
+            "RTL":["r_rtl","setup","r_caravan_rtl","gpio_rtl","push","push_gl","nightly","weekly","tape_out"],
+            "GL":["r_gl","r_caravan_gl","push_gl","gpio_gl","nightly","weekly","tape_out"],
             "GL_SDF":["r_sdf","weekly","tape_out"],
             "description":"configure all gpios as mgmt input pull up using automatic approach firmware and check them"}
 
@@ -51,15 +51,15 @@
 
         ,"gpio_all_i_pd" :{"level":0, 
             "SW":true,
-            "RTL":["r_rtl","setup","gpio_rtl","push","push_gl","nightly","weekly","tape_out"],
-            "GL":["r_gl","push_gl","gpio_gl","nightly","weekly","tape_out"],
+            "RTL":["r_rtl","setup","r_caravan_rtl","gpio_rtl","push","push_gl","nightly","weekly","tape_out"],
+            "GL":["r_gl","r_caravan_gl","push_gl","gpio_gl","nightly","weekly","tape_out"],
             "GL_SDF":["r_sdf","weekly","tape_out"],
             "description":"configure all gpios as mgmt input pull down using automatic approach firmware and check them"}
 
         ,"gpio_all_i_pd_user" :{"level":0, 
             "SW":true,
             "RTL":["r_rtl","setup","gpio_rtl","push","push_gl","nightly","weekly","tape_out"],
-            "GL":["r_gl","push_gl","gpio_gl","nightly","weekly","tape_out"],
+            "GL":["r_gl","r_caravan_gl","push_gl","gpio_gl","nightly","weekly","tape_out"],
             "GL_SDF":["r_sdf","weekly","tape_out"],
             "description":"configure all gpios as user input pull down using automatic approach firmware and check them"}
 
@@ -72,8 +72,8 @@
 
         ,"gpio_all_o" :{"level":0, 
             "SW":true,
-            "RTL":["r_rtl","setup","gpio_rtl","push","push_gl","nightly","weekly","tape_out"],
-            "GL":["r_gl","push_gl","gpio_gl","nightly","weekly","tape_out"],
+            "RTL":["r_rtl","setup","r_caravan_rtl","gpio_rtl","push","push_gl","nightly","weekly","tape_out"],
+            "GL":["r_gl","r_caravan_gl","push_gl","gpio_gl","nightly","weekly","tape_out"],
             "GL_SDF":["r_sdf","weekly","tape_out"],
             "description":"configure all gpios as mgmt output using automatic approach firmware and check them"}
 
@@ -85,8 +85,8 @@
             "description":"configure all gpios as user output using automatic approach firmware and check them"}
         ,"hk_regs_wr_wb_cpu" :{"level":0, 
             "SW":false,
-            "RTL":["r_rtl","setup","push","push_gl","nightly","weekly","tape_out"],
-            "GL":["r_gl","push_gl","nightly","weekly","tape_out"],
+            "RTL":["r_rtl","r_caravan_rtl","setup","push","push_gl","nightly","weekly","tape_out"],
+            "GL":["r_gl","r_caravan_gl","push_gl","nightly","weekly","tape_out"],
             "GL_SDF":["r_sdf","weekly","tape_out"],
             "description":"bit bash test for housekeeping registers"}
         ,"IRQ_timer" :{"level":2, 
@@ -125,8 +125,8 @@
             "description":"Same as bitbang_cpu_all_i but configure the gpio using the SPI not the firmware"}
         ,"hk_regs_wr_spi" :{"level":0, 
             "SW":false,
-            "RTL":["r_rtl","setup","push","push_gl","nightly","weekly","tape_out"],
-            "GL":["r_gl","push_gl","nightly","weekly","tape_out"],
+            "RTL":["r_rtl","r_caravan_rtl","setup","push","push_gl","nightly","weekly","tape_out"],
+            "GL":["r_gl","r_caravan_gl","push_gl","nightly","weekly","tape_out"],
             "GL_SDF":["r_sdf","weekly","tape_out"],
             "description":"write then read(the written value) from random housekeeping registers through the SPI housekeeping"}
 
@@ -207,8 +207,8 @@
 
         ,"mgmt_gpio_bidir" :{"level":0, 
             "SW":true,
-            "RTL":["r_rtl","setup","nightly","weekly","tape_out"],
-            "GL":["r_gl","nightly","weekly","tape_out"],
+            "RTL":["r_rtl","r_caravan_rtl","setup","nightly","weekly","tape_out"],
+            "GL":["r_gl","r_caravan_gl","nightly","weekly","tape_out"],
             "GL_SDF":["r_sdf","weekly","tape_out"],
             "description":"send random number of blinks through mgmt_gpio and expect to recieve the same number back "}    
 

--- a/verilog/rtl/__user_analog_project_wrapper.v
+++ b/verilog/rtl/__user_analog_project_wrapper.v
@@ -121,4 +121,33 @@ module user_analog_project_wrapper (
 // Dummy assignment so that we can take it through the openlane flow
 assign io_out = io_in;
 
+// splitting the address space to user address space and debug address space 
+// debug address space are the last 2 registers of user_project_wrapper address space
+wire wbs_cyc_i_user;
+wire  wbs_ack_o_user;
+wire [31:0] wbs_dat_o_user;
+
+wire  wbs_cyc_i_debug;
+wire wbs_ack_o_debug;
+wire [31:0] wbs_dat_o_debug;
+
+assign wbs_cyc_i_user  = (wbs_adr_i[31:3] != 29'h601FFFF) ? wbs_cyc_i : 0; 
+assign wbs_cyc_i_debug = (wbs_adr_i[31:3] == 29'h601FFFF) ? wbs_cyc_i : 0; 
+assign wbs_ack_o = (wbs_adr_i[31:3] == 28'h601FFFF) ? wbs_ack_o_debug : wbs_ack_o_user; 
+assign wbs_dat_o = (wbs_adr_i[31:3] == 28'h601FFFF) ? wbs_dat_o_debug : wbs_dat_o_user; 
+assign wbs_ack_o_user = 0;
+
+debug_regs debug(
+    .wb_clk_i(wb_clk_i),
+    .wb_rst_i(wb_rst_i),
+    .wbs_cyc_i(wbs_cyc_i_debug),
+    .wbs_stb_i(wbs_stb_i),
+    .wbs_we_i(wbs_we_i),
+    .wbs_sel_i(wbs_sel_i),
+    .wbs_adr_i(wbs_adr_i),
+    .wbs_dat_i(wbs_dat_i),
+    .wbs_ack_o(wbs_ack_o_debug),
+    .wbs_dat_o(wbs_dat_o_debug)
+);
+
 endmodule	// user_analog_project_wrapper


### PR DESCRIPTION
The pull request contain updates to cocotb environment to to be able simulate caravan with cocotb tests 
This update enables caravan siulation for iverilog. VCS still not supported 

To run 
just append any caravel simulation command with -caravel option examples of caravel simulation commands exists at [README.md](https://github.com/efabless/caravel/blob/caravel_redesign/verilog/dv/cocotb/doc/commands_example/README.md)

test list can be found at [README.md](https://github.com/efabless/caravel/blob/caravel_redesign/verilog/dv/cocotb/doc/tests/README.md) 

new regression has been added for caravan it contain all gpio and spi tests 

`python3 verify_cocotb.py -r r_caravan_rtl -tag caravan_rtl -caravan`
`python3 verify_cocotb.py -r r_caravan_gl -tag caravan_gl -caravan`
