### PR TITLE
Syntax changes that are non-functional from a synthesis perspective.

### DIFF
--- a/manifest
+++ b/manifest
@@ -28,8 +28,8 @@ ce49f9af199b5f16d2c39c417d58e5890bc7bab2  verilog/rtl/digital_pll_controller.v
 32d395d5936632f3c92a0de4867d6dd7cd4af1bb  verilog/rtl/gpio_logic_high.v
 095aba3128be2f6f776ddf66596249c85471cd75  verilog/rtl/gpio_signal_buffering.v
 1a7e1e050b963054f5b62784249f713c90eaaaf0  verilog/rtl/gpio_signal_buffering_alt.v
-77f162231c6a8060eef9a228f9b843751ac6fb03  verilog/rtl/housekeeping.v
-3030f955d5f110d24012bd1562c0e18c1a0d04e2  verilog/rtl/housekeeping_spi.v
+0dc5b899412a3a3a3a8ccf662bad1056d294f50b  verilog/rtl/housekeeping.v
+34c6ab585986a00216c72f2f1fea0e5a8523867b  verilog/rtl/housekeeping_spi.v
 ee3fbd794fcc6d221562147b09891e315873ac4c  verilog/rtl/mgmt_protect.v
 3b1ff20593bc386d13f5e2cf1571f08121889957  verilog/rtl/mgmt_protect_hv.v
 9816acedf3dc3edd193861cc217ec46180ac1cdd  verilog/rtl/mprj2_logic_high.v

--- a/verilog/rtl/housekeeping.v
+++ b/verilog/rtl/housekeeping.v
@@ -254,6 +254,12 @@ module housekeeping #(
     wire	cwstb;	// Combination of SPI write strobe and back door write strobe
     wire	csclk;	// Combination of SPI SCK and back door access trigger
 
+    wire serial_data_1;
+    wire serial_data_2;
+    wire serial_clock;
+    wire serial_resetn;
+    wire serial_load;
+
 // Output clock signals buffer wires
 wire mgmt_gpio_out_9_prebuff, mgmt_gpio_out_14_prebuff, mgmt_gpio_out_15_prebuff, pad_flash_clk_prebuff;
 
@@ -912,11 +918,6 @@ wire mgmt_gpio_out_9_prebuff, mgmt_gpio_out_14_prebuff, mgmt_gpio_out_15_prebuff
     reg serial_clock_pre;
     reg serial_resetn_pre;
     reg serial_load_pre;
-    wire serial_data_1;
-    wire serial_data_2;
-    wire serial_clock;
-    wire serial_resetn;
-    wire serial_load;
     reg [IO_CTRL_BITS-1:0] serial_data_staging_1;
     reg [IO_CTRL_BITS-1:0] serial_data_staging_2;
 

--- a/verilog/rtl/housekeeping_spi.v
+++ b/verilog/rtl/housekeeping_spi.v
@@ -183,7 +183,7 @@ module housekeeping_spi(reset, SCK, SDI, CSB, SDO,
 	    pass_thru_mgmt <= 1'b0;
 	    pass_thru_mgmt_delay <= 1'b0;
 	    pre_pass_thru_mgmt <= 1'b0;
-	    pass_thru_user = 1'b0;
+	    pass_thru_user <= 1'b0;
 	    pass_thru_user_delay <= 1'b0;
 	    pre_pass_thru_user <= 1'b0;
         end else begin


### PR DESCRIPTION
There are a few errors that are caught by commercial tools and halt synthesis, which are handled more gracefully by the open source tool flow.  In housekeeping.v:  Some wires declared after they are used.  In housekeeping_spi.v:  A non-blocking "=" assignment used where a blocking "<-" assignment was intended.

This pull request takes the place of #299 from Stanford, which was meant to be advisory and not intended to be merged.