### PR TITLE
Fixes to caravan for LVS and ERC

### DIFF
--- a/mag/chip_io_alt.mag
+++ b/mag/chip_io_alt.mag
@@ -1,35 +1,113 @@
 magic
 tech sky130A
 magscale 1 2
-timestamp 1666101961
+timestamp 1666377896
 << checkpaint >>
-rect 674147 861036 677147 879369
-rect 40453 783431 43453 801764
-rect 674147 771836 677147 790169
-rect 40453 740231 43453 758564
-rect 674147 726836 677147 745169
-rect 40453 697031 43453 715364
-rect 674147 681836 677147 700169
-rect 40453 653831 43453 672164
-rect 674147 636636 677147 654969
-rect 40453 610631 43453 628964
-rect 674147 591636 677147 609969
-rect 40453 567431 43453 585764
-rect 674147 546436 677147 564769
-rect 40453 524231 43453 542564
-rect 40453 396631 43453 414964
-rect 40453 353431 43453 371764
-rect 674147 369236 677147 387569
-rect 40453 310231 43453 328564
-rect 674147 324036 677147 342369
-rect 40453 267031 43453 285364
-rect 674147 279036 677147 297369
-rect 40453 223831 43453 242164
-rect 674147 234036 677147 252369
-rect 40453 180631 43453 198964
-rect 674147 188836 677147 207169
-rect 674147 143836 677147 162169
-rect 674147 98636 677147 116969
+rect -1260 996747 718860 1038860
+rect -1260 996340 42060 996747
+rect 75940 996340 93460 996747
+rect 127340 996340 144860 996747
+rect 178740 996340 196260 996747
+rect 219740 996340 256060 996747
+rect 272340 996340 308660 996747
+rect 332140 996340 349660 996747
+rect 374140 996340 410460 996747
+rect 472540 996340 490060 996747
+rect 523940 996340 541460 996747
+rect 574340 996340 591860 996747
+rect 625740 996340 643260 996747
+rect -1260 971460 40853 996340
+rect 676340 995540 718860 996747
+rect -1260 953940 41260 971460
+rect 676747 967860 718860 995540
+rect -1260 930447 40853 953940
+rect 676340 950340 718860 967860
+rect -1260 910740 43030 930447
+rect 676747 923860 718860 950340
+rect -1260 886060 40853 910740
+rect 674570 904153 718860 923860
+rect -1260 868540 41260 886060
+rect 676747 879692 718860 904153
+rect -1260 843860 40853 868540
+rect 674147 861036 718860 879692
+rect -1260 826340 41260 843860
+rect -1260 801764 40853 826340
+rect -1260 783108 43453 801764
+rect 674422 790492 718860 861036
+rect -1260 758564 40853 783108
+rect 674147 771836 718860 790492
+rect -1260 739908 43453 758564
+rect 674422 745492 718860 771836
+rect -1260 715364 40853 739908
+rect 674147 726836 718860 745492
+rect -1260 696708 43453 715364
+rect 674422 700492 718860 726836
+rect -1260 672164 40853 696708
+rect 674147 681836 718860 700492
+rect -1260 653508 43453 672164
+rect 674422 655292 718860 681836
+rect -1260 628964 40853 653508
+rect 674147 636636 718860 655292
+rect -1260 610308 43453 628964
+rect -1260 585764 40853 610308
+rect 674422 610292 718860 636636
+rect 674147 591636 718860 610292
+rect -1260 567108 43453 585764
+rect -1260 542564 40853 567108
+rect 674422 565092 718860 591636
+rect 674147 546436 718860 565092
+rect -1260 523908 43453 542564
+rect -1260 499260 40853 523908
+rect -1260 481740 41260 499260
+rect -1260 459247 40853 481740
+rect -1260 439540 43030 459247
+rect -1260 414964 40853 439540
+rect -1260 396308 43453 414964
+rect -1260 371764 40853 396308
+rect 674422 387892 718860 546436
+rect -1260 353108 43453 371764
+rect 674147 369236 718860 387892
+rect 674422 369084 718860 369236
+rect -1260 328564 40853 353108
+rect 676747 342692 718860 369084
+rect -1260 309908 43453 328564
+rect 674147 324036 718860 342692
+rect -1260 285364 40853 309908
+rect 676747 297692 718860 324036
+rect -1260 266708 43453 285364
+rect 674147 279036 718860 297692
+rect -1260 242164 40853 266708
+rect 676747 252692 718860 279036
+rect -1260 223508 43453 242164
+rect 674147 234036 718860 252692
+rect -1260 198964 40853 223508
+rect 676747 207492 718860 234036
+rect -1260 180308 43453 198964
+rect 674147 188836 718860 207492
+rect -1260 126460 40853 180308
+rect 676747 162492 718860 188836
+rect 674147 143836 718860 162492
+rect -1260 108940 41260 126460
+rect 676747 117292 718860 143836
+rect -1260 86499 40853 108940
+rect 674147 98636 718860 117292
+rect -1260 66740 42960 86499
+rect -1260 42060 40853 66740
+rect -1260 40853 41260 42060
+rect 77540 40853 95060 41260
+rect 131216 40853 148963 41260
+rect 185108 40853 203692 43453
+rect 237701 40853 257460 42960
+rect 293708 40853 312292 43453
+rect 348508 40853 367092 43453
+rect 403308 40853 421892 43453
+rect 458108 40853 476692 43453
+rect 512908 40853 531492 43453
+rect 676747 41260 718860 98636
+rect 567740 40853 585260 41260
+rect 621540 40853 639060 41260
+rect 675540 40853 718860 41260
+rect -1260 -1260 718860 40853
 << metal1 >>
 rect 41866 42181 41918 784786
 rect 411070 42422 411076 42474
@@ -77,7 +155,7 @@ rect 518860 42308 524972 42336
 rect 518860 42296 518866 42308
 rect 524966 42296 524972 42308
 rect 525024 42296 525030 42348
-rect 675682 42181 675734 370592
+rect 675682 42181 675734 862296
 rect 41866 42129 145035 42181
 rect 145207 42129 195328 42181
 rect 195380 42129 199653 42181
@@ -1761,2859 +1839,2859 @@ rect 515440 6598 527960 19088
 rect 570422 6811 582590 18975
 rect 624222 6811 636390 18975
 use sky130_ef_io__com_bus_slice_20um  FILLER_5 $PDKPATH/libs.ref/sky130_fd_io/maglef
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 40800 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_6
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 44800 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_7
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 48800 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_8
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 52800 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_9
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 56800 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_10
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 60800 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_11
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 64800 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_12
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 68800 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_13
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 72800 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_14 $PDKPATH/libs.ref/sky130_fd_io/maglef
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 76800 0 1 998007
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_15
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 77000 0 1 998007
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_17
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 92200 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_18
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 96200 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_19
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 100200 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_20
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 104200 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_21
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 108200 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_22
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 112200 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_23
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 116200 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_24
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 120200 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_25
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 124200 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_26
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 128200 0 1 998007
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_27
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 128400 0 1 998007
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_29
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 143600 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_30
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 147600 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_31
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 151600 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_32
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 155600 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_33
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 159600 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_34
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 163600 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_35
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 167600 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_36
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 171600 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_37
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 175600 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_38
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 179600 0 1 998007
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_39
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 179800 0 1 998007
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_41
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 195000 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_42
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 199000 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_43
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 203000 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_44
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 207000 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_45
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 211000 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_46
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 215000 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_47 $PDKPATH/libs.ref/sky130_fd_io/maglef
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 219000 0 1 998007
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_49
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 254800 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_50
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 258800 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_51
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 262800 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_52
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 266800 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_53 $PDKPATH/libs.ref/sky130_fd_io/maglef
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 270800 0 1 998007
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_54
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 271800 0 1 998007
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_55
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 272000 0 1 998007
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_56
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 272200 0 1 998007
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_57
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 272400 0 1 998007
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_60
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 310400 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_61
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 314400 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_62
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 318400 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_63
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 322400 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_64
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 326400 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_65
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 330400 0 1 998007
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_66
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 332400 0 1 998007
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_68
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 348400 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_69
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 352400 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_70
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 356400 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_71
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 360400 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_72
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 364400 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_73
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 368400 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_78
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 412200 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_79
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 416200 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_80
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 420200 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_81
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 424200 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_82
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 428200 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_83
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 432200 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_84
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 436200 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_85
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 440200 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_86
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 444200 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_87
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 448200 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_88
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 452200 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_89
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 456200 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_90
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 460200 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_91
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 464200 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_92
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 468200 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_93
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 472200 0 1 998007
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_94
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 473200 0 1 998007
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_95
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 473400 0 1 998007
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_96
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 473600 0 1 998007
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_98
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 488800 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_99
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 492800 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_100
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 496800 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_101
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 500800 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_102
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 504800 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_103
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 508800 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_104
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 512800 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_105
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 516800 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_106
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 520800 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_107
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 524800 0 1 998007
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_108
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 525000 0 1 998007
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_110
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 540200 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_111
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 544200 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_112
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 548200 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_113
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 552200 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_114
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 556200 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_115
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 560200 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_116
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 564200 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_117
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 568200 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_118
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 572200 0 1 998007
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_119
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 574200 0 1 998007
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_120
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 575200 0 1 998007
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_121
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 575400 0 1 998007
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_123
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 590600 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_124
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 594600 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_125
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 598600 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_126
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 602600 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_127
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 606600 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_128
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 610600 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_129
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 614600 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_130
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 618600 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_131
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 622600 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_132
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 626600 0 1 998007
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_133
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 626800 0 1 998007
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_135
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 642000 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_136
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 646000 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_137
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 650000 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_138
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 654000 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_139
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 658000 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_140
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 662000 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_141
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 666000 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_142
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 670000 0 1 998007
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_143
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 674000 0 1 998007
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_144
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 676000 0 1 998007
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_145
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 677000 0 1 998007
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_146
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 677200 0 1 998007
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_147
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 677400 0 1 998007
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_148
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 44000 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_149
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 46000 0 -1 39593
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_150
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 47000 0 -1 39593
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_151
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 47200 0 -1 39593
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_152
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 47400 0 -1 39593
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_159
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 75400 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_160
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 77400 0 -1 39593
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_161
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 78400 0 -1 39593
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_162
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 78600 0 -1 39593
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_163
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 78800 0 -1 39593
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_165
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 97800 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_166
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 99800 0 -1 39593
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_167
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 100800 0 -1 39593
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_168
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 101000 0 -1 39593
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_169
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 101200 0 -1 39593
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_176
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 129200 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_177
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 131200 0 -1 39593
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_178
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 132200 0 -1 39593
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_179
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 132400 0 -1 39593
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_180
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 132600 0 -1 39593
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_182
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 151600 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_183
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 153600 0 -1 39593
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_184
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 154600 0 -1 39593
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_185
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 154800 0 -1 39593
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_186
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 155000 0 -1 39593
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_193
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 183000 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_194
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 185000 0 -1 39593
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_195
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 186000 0 -1 39593
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_196
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 186200 0 -1 39593
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_197
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 186400 0 -1 39593
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_199
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 206400 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_200
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 208400 0 -1 39593
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_201
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 209400 0 -1 39593
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_202
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 209600 0 -1 39593
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_203
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 209800 0 -1 39593
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_210
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 237800 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_211
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 239800 0 -1 39593
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_212
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 240800 0 -1 39593
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_213
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 241000 0 -1 39593
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_214
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 241200 0 -1 39593
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_216
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 260200 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_217
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 262200 0 -1 39593
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_218
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 263200 0 -1 39593
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_219
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 263400 0 -1 39593
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_220
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 263600 0 -1 39593
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_227
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 291600 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_228
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 293600 0 -1 39593
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_229
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 294600 0 -1 39593
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_230
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 294800 0 -1 39593
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_231
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 295000 0 -1 39593
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_233
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 315000 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_234
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 317000 0 -1 39593
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_235
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 318000 0 -1 39593
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_236
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 318200 0 -1 39593
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_237
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 318400 0 -1 39593
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_244
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 346400 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_245
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 348400 0 -1 39593
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_246
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 349400 0 -1 39593
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_247
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 349600 0 -1 39593
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_248
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 349800 0 -1 39593
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_250
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 369800 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_251
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 371800 0 -1 39593
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_252
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 372800 0 -1 39593
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_253
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 373000 0 -1 39593
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_254
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 373200 0 -1 39593
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_261
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 401200 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_262
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 403200 0 -1 39593
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_263
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 404200 0 -1 39593
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_264
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 404400 0 -1 39593
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_265
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 404600 0 -1 39593
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_267
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 424600 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_268
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 426600 0 -1 39593
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_269
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 427600 0 -1 39593
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_270
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 427800 0 -1 39593
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_271
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 428000 0 -1 39593
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_278
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 456000 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_279
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 458000 0 -1 39593
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_280
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 459000 0 -1 39593
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_281
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 459200 0 -1 39593
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_282
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 459400 0 -1 39593
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_284
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 479400 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_285
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 481400 0 -1 39593
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_286
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 482400 0 -1 39593
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_287
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 482600 0 -1 39593
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_288
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 482800 0 -1 39593
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_295
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 510800 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_296
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 512800 0 -1 39593
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_297
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 513800 0 -1 39593
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_298
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 514000 0 -1 39593
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_299
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 514200 0 -1 39593
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_301
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 534200 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_302
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 536200 0 -1 39593
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_303
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 537200 0 -1 39593
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_304
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 537400 0 -1 39593
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_305
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 537600 0 -1 39593
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_312
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 565600 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_313
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 567600 0 -1 39593
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_314
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 568600 0 -1 39593
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_315
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 568800 0 -1 39593
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_316
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 569000 0 -1 39593
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_318
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 588000 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_319
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 590000 0 -1 39593
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_320
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 591000 0 -1 39593
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_321
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 591200 0 -1 39593
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_322
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 591400 0 -1 39593
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_329
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 619400 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_330
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 621400 0 -1 39593
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_331
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 622400 0 -1 39593
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_332
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 622600 0 -1 39593
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_333
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 622800 0 -1 39593
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_335
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 641800 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_336
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 643800 0 -1 39593
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_337
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 644800 0 -1 39593
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_338
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 645000 0 -1 39593
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_339
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 645200 0 -1 39593
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_346
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 673200 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_347
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 675200 0 -1 39593
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_348
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 676200 0 -1 39593
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_349
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 676400 0 -1 39593
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_350
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 676600 0 -1 39593
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_351
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 676800 0 -1 39593
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_352
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 40800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_353
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 44800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_354
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 48800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_355
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 52800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_356
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 56800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_357
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 60800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_358
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 64800
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_359
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 66800
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_360
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 67800
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_362
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 83000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_363
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 87000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_364
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 91000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_365
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 95000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_366
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 99000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_367
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 103000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_368
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 107000
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_369
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 109000
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_370
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 110000
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_374
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 127200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_375
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 131200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_376
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 135200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_377
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 139200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_378
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 143200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_379
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 147200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_380
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 151200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_381
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 155200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_382
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 159200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_383
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 163200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_384
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 167200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_385
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 171200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_386
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 175200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_387
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 179200
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_388
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 181200
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_389
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 181400
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_391
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 197600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_392
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 201600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_393
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 205600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_394
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 209600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_395
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 213600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_396
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 217600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_397
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 221600
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_398
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 223600
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_399
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 224600
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_401
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 240800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_402
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 244800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_403
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 248800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_404
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 252800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_405
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 256800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_406
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 260800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_407
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 264800
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_408
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 266800
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_409
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 267800
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_411
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 284000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_412
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 288000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_413
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 292000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_414
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 296000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_415
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 300000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_416
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 304000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_417
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 308000
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_418
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 310000
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_419
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 311000
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_421
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 327200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_422
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 331200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_423
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 335200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_424
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 339200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_425
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 343200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_426
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 347200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_427
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 351200
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_428
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 353200
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_429
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 354200
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_431
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 370400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_432
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 374400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_433
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 378400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_434
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 382400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_435
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 386400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_436
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 390400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_437
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 394400
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_438
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 396400
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_439
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 397400
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_441
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 413600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_442
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 417600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_443
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 421600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_444
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 425600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_445
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 429600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_446
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 433600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_447
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 437600
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_448
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 439600
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_449
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 440600
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_451
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 455800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_452
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 459800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_453
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 463800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_454
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 467800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_455
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 471800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_456
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 475800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_457
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 479800
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_458
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 481800
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_459
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 482800
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_461
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 498000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_462
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 502000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_463
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 506000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_464
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 510000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_465
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 514000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_466
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 518000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_467
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 522000
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_468
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 524000
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_469
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 525000
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_471
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 541200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_472
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 545200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_473
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 549200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_474
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 553200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_475
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 557200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_476
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 561200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_477
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 565200
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_478
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 567200
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_479
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 568200
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_481
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 584400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_482
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 588400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_483
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 592400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_484
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 596400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_485
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 600400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_486
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 604400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_487
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 608400
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_488
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 610400
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_489
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 611400
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_491
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 627600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_492
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 631600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_493
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 635600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_494
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 639600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_495
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 643600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_496
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 647600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_497
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 651600
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_498
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 653600
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_499
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 654600
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_501
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 670800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_502
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 674800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_503
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 678800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_504
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 682800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_505
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 686800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_506
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 690800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_507
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 694800
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_508
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 696800
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_509
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 697800
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_511
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 714000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_512
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 718000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_513
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 722000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_514
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 726000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_515
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 730000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_516
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 734000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_517
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 738000
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_518
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 740000
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_519
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 741000
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_521
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 757200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_522
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 761200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_523
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 765200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_524
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 769200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_525
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 773200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_526
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 777200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_527
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 781200
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_528
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 783200
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_529
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 784200
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_531
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 800400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_532
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 804400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_533
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 808400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_534
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 812400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_535
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 816400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_536
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 820400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_537
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 824400
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_538
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 826400
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_539
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 827400
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_541
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 842600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_542
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 846600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_543
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 850600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_544
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 854600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_545
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 858600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_546
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 862600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_547
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 866600
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_548
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 868600
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_549
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 869600
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_551
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 884800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_552
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 888800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_553
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 892800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_554
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 896800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_555
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 900800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_556
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 904800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_557
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 908800
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_558
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 910800
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_559
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 911800
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_561
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 927000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_562
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 931000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_563
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 935000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_564
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 939000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_565
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 943000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_566
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 947000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_567
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 951000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_568
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 955000
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_570
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 970200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_571
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 974200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_572
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 978200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_573
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 982200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_574
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 986200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_575
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 990200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_576
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 994200
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_577
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 996200
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_578
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 997200
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_579
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 997400
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_580
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 44000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_581
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 48000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_582
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 52000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_583
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 56000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_584
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 60000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_585
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 64000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_586
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 68000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_587
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 69000
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_590
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 75000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_591
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 79000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_592
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 83000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_593
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 87000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_594
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 91000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_595
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 95000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_596
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 99000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_597
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 100000
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_599
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 120000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_600
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 124000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_601
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 128000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_602
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 132000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_603
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 136000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_604
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 140000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_605
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 144000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_606
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 145000
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_607
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 145200
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_609
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 165200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_610
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 169200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_611
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 173200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_612
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 177200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_613
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 181200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_614
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 185200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_615
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 189200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_616
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 190200
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_618
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 210200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_619
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 214200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_620
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 218200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_621
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 222200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_622
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 226200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_623
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 230200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_624
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 234200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_625
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 235200
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_626
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 235400
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_628
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 255400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_629
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 259400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_630
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 263400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_631
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 267400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_632
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 271400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_633
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 275400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_634
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 279400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_635
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 280400
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_637
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 300400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_638
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 304400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_639
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 308400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_640
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 312400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_641
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 316400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_642
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 320400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_643
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 324400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_644
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 325400
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_646
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 345400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_647
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 349400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_648
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 353400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_649
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 357400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_650
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 361400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_651
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 365400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_652
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 369400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_653
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 370400
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_654
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 370600
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_656
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 390600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_657
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 394600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_658
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 398600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_659
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 402600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_660
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 406600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_661
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 410600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_662
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 414600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_663
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 415600
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_665
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 434600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_666
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 438600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_667
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 442600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_668
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 446600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_669
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 450600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_670
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 454600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_671
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 458600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_672
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 459600
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_673
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 459800
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_675
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 478800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_676
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 482800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_677
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 486800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_678
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 490800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_679
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 494800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_680
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 498800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_681
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 502800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_682
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 503800
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_684
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 522800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_685
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 526800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_686
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 530800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_687
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 534800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_688
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 538800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_689
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 542800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_690
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 546800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_691
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 547800
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_693
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 567800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_694
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 571800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_695
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 575800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_696
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 579800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_697
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 583800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_698
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 587800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_699
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 591800
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_700
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 592800
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_701
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 593000
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_703
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 613000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_704
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 617000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_705
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 621000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_706
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 625000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_707
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 629000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_708
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 633000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_709
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 637000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_710
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 638000
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_712
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 658000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_713
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 662000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_714
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 666000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_715
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 670000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_716
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 674000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_717
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 678000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_718
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 682000
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_719
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 683000
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_720
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 683200
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_722
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 703200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_723
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 707200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_724
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 711200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_725
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 715200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_726
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 719200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_727
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 723200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_728
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 727200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_729
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 728200
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_731
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 748200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_732
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 752200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_733
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 756200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_734
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 760200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_735
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 764200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_736
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 768200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_737
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 772200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_738
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 773200
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_740
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 793200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_741
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 797200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_742
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 801200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_743
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 805200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_744
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 809200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_745
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 813200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_746
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 817200
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_747
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 818200
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_748
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 818400
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_750
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 837400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_751
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 841400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_752
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 845400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_753
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 849400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_754
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 853400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_755
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 857400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_756
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 861400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_757
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 862400
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_759
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 882400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_760
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 886400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_761
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 890400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_762
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 894400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_763
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 898400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_764
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 902400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_765
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 906400
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_766
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 907400
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_767
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 907600
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_769
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 926600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_770
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 930600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_771
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 934600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_772
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 938600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_773
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 942600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_774
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 946600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_775
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 950600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_10um  FILLER_776
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 968600
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_777
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 951600
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_779
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 972600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_780
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 976600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_781
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 980600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_782
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 984600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_783
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 988600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_784
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 992600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_20um  FILLER_785
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 996600
 box 0 0 4000 39593
 use sky130_ef_io__com_bus_slice_1um  FILLER_786
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 996800
 box 0 0 200 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_SB1
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 71000
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_SB2
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 126200
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_5um  FILLER_SB3
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 373400 0 1 998007
 box 0 0 1000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_1 $PDKPATH/libs.ref/sky130_fd_io/maglef
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 51400 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_2
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 55400 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_3
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 59400 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_4
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 63400 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_5
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 67400 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_6
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 71400 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_7
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 105200 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_8
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 109200 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_9
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 113200 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_10
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 117200 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_11
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 121200 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_12
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 125200 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_13
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 159000 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_14
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 163000 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_15
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 167000 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_16
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 171000 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_17
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 175000 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_18
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 179000 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_19
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 213800 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_20
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 217800 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_21
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 221800 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_22
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 225800 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_23
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 229800 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_24
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 233800 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_25
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 267600 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_26
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 271600 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_27
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 275600 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_28
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 279600 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_29
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 283600 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_30
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 287600 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_31
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 322400 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_32
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 326400 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_33
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 330400 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_34
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 334400 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_35
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 338400 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_36
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 342400 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_37
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 377200 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_38
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 381200 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_39
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 385200 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_40
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 389200 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_41
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 393200 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_42
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 397200 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_43
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 432000 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_44
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 436000 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_45
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 440000 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_46
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 444000 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_47
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 448000 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_48
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 452000 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_49
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 486800 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_50
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 490800 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_51
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 494800 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_52
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 498800 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_53
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 502800 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_54
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 506800 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_55
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 541600 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_56
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 545600 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_57
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 549600 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_58
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 553600 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_59
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 557600 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_60
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 561600 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_61
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 595400 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_62
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 599400 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_63
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 603400 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_64
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 607400 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_65
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 611400 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_66
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 615400 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_67
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 649200 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_68
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 653200 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_69
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 657200 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_70
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 661200 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_71
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 665200 0 -1 39593
 box 0 0 4000 39593
 use sky130_ef_io__connect_vcchib_vccd_and_vswitch_vddio_slice_20um  bus_tie_72
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 669200 0 -1 39593
 box 0 0 4000 39593
 use chip_io_gpio_connects  chip_io_gpio_connects_0
@@ -4725,7 +4803,7 @@ timestamp 1666101711
 transform -1 0 717600 0 -1 340800
 box 675407 99896 675887 115709
 use sky130_ef_io__gpiov2_pad_wrapped  clock_pad $PDKPATH/libs.ref/sky130_fd_io/maglef
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 202400 0 -1 42193
 box -32 0 16032 42193
 use constant_block  constant_block_0 ../maglef
@@ -4757,303 +4835,303 @@ timestamp 1665254081
 transform -1 0 534616 0 1 39608
 box 0 496 2800 2224
 use sky130_ef_io__disconnect_vdda_slice_5um  disconnect_vdda_0 $PDKPATH/libs.ref/sky130_fd_io/maglef
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 372400 0 1 998007
 box 0 0 1000 39593
 use sky130_ef_io__disconnect_vdda_slice_5um  disconnect_vdda_1
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 70000
 box 0 0 1000 39593
 use sky130_ef_io__disconnect_vdda_slice_5um  disconnect_vdda_2
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 125200
 box 0 0 1000 39593
 use sky130_ef_io__gpiov2_pad_wrapped  flash_clk_pad
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 365800 0 -1 42193
 box -32 0 16032 42193
 use sky130_ef_io__gpiov2_pad_wrapped  flash_csb_pad
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 311000 0 -1 42193
 box -32 0 16032 42193
 use sky130_ef_io__gpiov2_pad_wrapped  flash_io0_pad
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 420600 0 -1 42193
 box -32 0 16032 42193
 use sky130_ef_io__gpiov2_pad_wrapped  flash_io1_pad
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 475400 0 -1 42193
 box -32 0 16032 42193
 use sky130_ef_io__gpiov2_pad_wrapped  gpio_pad
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 530200 0 -1 42193
 box -32 0 16032 42193
 use sky130_ef_io__corner_pad  mgmt_corner\[0\] $PDKPATH/libs.ref/sky130_fd_io/maglef
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 40000 0 -1 40800
 box 0 0 40000 40800
 use sky130_ef_io__corner_pad  mgmt_corner\[1\]
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 676800 -1 0 40000
 box 0 0 40000 40800
 use sky130_ef_io__vccd_lvc_clamped_pad  mgmt_vccd_lvclamp_pad $PDKPATH/libs.ref/sky130_fd_io/maglef
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 68000
 box 0 -2107 17239 39593
 use sky130_ef_io__vdda_hvc_clamped_pad  mgmt_vdda_hvclamp_pad $PDKPATH/libs.ref/sky130_fd_io/maglef
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 637800 0 -1 39593
 box 0 -407 15000 39593
 use sky130_ef_io__vddio_hvc_clamped_pad  mgmt_vddio_hvclamp_pad\[0\] $PDKPATH/libs.ref/sky130_fd_io/maglef
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 110200
 box 0 -407 15000 39593
 use sky130_ef_io__vddio_hvc_clamped_pad  mgmt_vddio_hvclamp_pad\[1\]
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 869800
 box 0 -407 15000 39593
 use sky130_ef_io__vssa_hvc_clamped_pad  mgmt_vssa_hvclamp_pad $PDKPATH/libs.ref/sky130_fd_io/maglef
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 93800 0 -1 39593
 box 0 -407 15000 39593
 use sky130_ef_io__vssd_lvc_clamped_pad  mgmt_vssd_lvclamp_pad $PDKPATH/libs.ref/sky130_fd_io/maglef
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 256200 0 -1 39593
 box 0 -2107 17239 39593
 use sky130_ef_io__vssio_hvc_clamped_pad  mgmt_vssio_hvclamp_pad\[0\] $PDKPATH/libs.ref/sky130_fd_io/maglef
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 584000 0 -1 39593
 box 0 -407 15000 39593
 use sky130_ef_io__vssio_hvc_clamped_pad  mgmt_vssio_hvclamp_pad\[1\]
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 333400 0 1 998007
 box 0 -407 15000 39593
 use sky130_ef_io__gpiov2_pad_wrapped  mprj_pads.area1_io_pad\[0\]
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 675407 -1 0 116000
 box -32 0 16032 42193
 use sky130_ef_io__gpiov2_pad_wrapped  mprj_pads.area1_io_pad\[1\]
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 675407 -1 0 161200
 box -32 0 16032 42193
 use sky130_ef_io__gpiov2_pad_wrapped  mprj_pads.area1_io_pad\[2\]
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 675407 -1 0 206200
 box -32 0 16032 42193
 use sky130_ef_io__gpiov2_pad_wrapped  mprj_pads.area1_io_pad\[3\]
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 675407 -1 0 251400
 box -32 0 16032 42193
 use sky130_ef_io__gpiov2_pad_wrapped  mprj_pads.area1_io_pad\[4\]
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 675407 -1 0 296400
 box -32 0 16032 42193
 use sky130_ef_io__gpiov2_pad_wrapped  mprj_pads.area1_io_pad\[5\]
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 675407 -1 0 341400
 box -32 0 16032 42193
 use sky130_ef_io__gpiov2_pad_wrapped  mprj_pads.area1_io_pad\[6\]
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 675407 -1 0 386600
 box -32 0 16032 42193
 use sky130_ef_io__gpiov2_pad_wrapped  mprj_pads.area1_io_pad\[7\]
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 675407 -1 0 563800
 box -32 0 16032 42193
 use sky130_ef_io__gpiov2_pad_wrapped  mprj_pads.area1_io_pad\[8\]
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 675407 -1 0 609000
 box -32 0 16032 42193
 use sky130_ef_io__gpiov2_pad_wrapped  mprj_pads.area1_io_pad\[9\]
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 675407 -1 0 654000
 box -32 0 16032 42193
 use sky130_ef_io__gpiov2_pad_wrapped  mprj_pads.area1_io_pad\[10\]
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 675407 -1 0 699200
 box -32 0 16032 42193
 use sky130_ef_io__gpiov2_pad_wrapped  mprj_pads.area1_io_pad\[11\]
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 675407 -1 0 744200
 box -32 0 16032 42193
 use sky130_ef_io__gpiov2_pad_wrapped  mprj_pads.area1_io_pad\[12\]
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 675407 -1 0 789200
 box -32 0 16032 42193
 use sky130_ef_io__gpiov2_pad_wrapped  mprj_pads.area1_io_pad\[13\]
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 675407 -1 0 878400
 box -32 0 16032 42193
 use sky130_ef_io__gpiov2_pad_wrapped  mprj_pads.area2_io_pad\[0\]
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 42193 1 0 784400
 box -32 0 16032 42193
 use sky130_ef_io__gpiov2_pad_wrapped  mprj_pads.area2_io_pad\[1\]
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 42193 1 0 741200
 box -32 0 16032 42193
 use sky130_ef_io__gpiov2_pad_wrapped  mprj_pads.area2_io_pad\[2\]
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 42193 1 0 698000
 box -32 0 16032 42193
 use sky130_ef_io__gpiov2_pad_wrapped  mprj_pads.area2_io_pad\[3\]
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 42193 1 0 654800
 box -32 0 16032 42193
 use sky130_ef_io__gpiov2_pad_wrapped  mprj_pads.area2_io_pad\[4\]
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 42193 1 0 611600
 box -32 0 16032 42193
 use sky130_ef_io__gpiov2_pad_wrapped  mprj_pads.area2_io_pad\[5\]
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 42193 1 0 568400
 box -32 0 16032 42193
 use sky130_ef_io__gpiov2_pad_wrapped  mprj_pads.area2_io_pad\[6\]
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 42193 1 0 525200
 box -32 0 16032 42193
 use sky130_ef_io__gpiov2_pad_wrapped  mprj_pads.area2_io_pad\[7\]
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 42193 1 0 397600
 box -32 0 16032 42193
 use sky130_ef_io__gpiov2_pad_wrapped  mprj_pads.area2_io_pad\[8\]
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 42193 1 0 354400
 box -32 0 16032 42193
 use sky130_ef_io__gpiov2_pad_wrapped  mprj_pads.area2_io_pad\[9\]
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 42193 1 0 311200
 box -32 0 16032 42193
 use sky130_ef_io__gpiov2_pad_wrapped  mprj_pads.area2_io_pad\[10\]
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 42193 1 0 268000
 box -32 0 16032 42193
 use sky130_ef_io__gpiov2_pad_wrapped  mprj_pads.area2_io_pad\[11\]
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 42193 1 0 224800
 box -32 0 16032 42193
 use sky130_ef_io__gpiov2_pad_wrapped  mprj_pads.area2_io_pad\[12\]
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 42193 1 0 181600
 box -32 0 16032 42193
 use sky130_fd_io__top_xres4v2  resetb_pad $PDKPATH/libs.ref/sky130_fd_io/maglef
-timestamp 1663859327
+timestamp 1666199351
 transform -1 0 147600 0 -1 40000
 box -103 0 15124 40000
 use sky130_ef_io__com_bus_slice_5um  sky130_ef_io__com_bus_slice_5um_0
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 374400 0 1 998007
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_5um  sky130_ef_io__com_bus_slice_5um_1
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 409200 0 1 998007
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_5um  sky130_ef_io__com_bus_slice_5um_2
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 272600 0 1 998007
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_5um  sky130_ef_io__com_bus_slice_5um_3
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 307400 0 1 998007
 box 0 0 1000 39593
 use sky130_ef_io__com_bus_slice_10um  sky130_ef_io__com_bus_slice_10um_0
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 410200 0 1 998007
 box 0 0 2000 39593
 use sky130_ef_io__com_bus_slice_10um  sky130_ef_io__com_bus_slice_10um_1
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 308400 0 1 998007
 box 0 0 2000 39593
 use sky130_ef_io__analog_pad  user1_analog_pad\[0\] $PDKPATH/libs.ref/sky130_fd_io/maglef
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 627000 0 1 997600
 box 0 0 15000 40000
 use sky130_ef_io__analog_pad  user1_analog_pad\[1\]
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 525200 0 1 997600
 box 0 0 15000 40000
 use sky130_ef_io__analog_pad  user1_analog_pad\[2\]
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 473800 0 1 997600
 box 0 0 15000 40000
 use sky130_ef_io__analog_pad  user1_analog_pad\[3\]
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 677600 -1 0 966600
 box 0 0 15000 40000
 use sky130_ef_io__top_power_hvc  user1_analog_pad_with_clamp $PDKPATH/libs.ref/sky130_fd_io/maglef
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 375400 0 1 998007
 box 0 -407 33800 39593
 use sky130_ef_io__corner_pad  user1_corner
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 677600 0 1 996800
 box 0 0 40000 40800
 use sky130_ef_io__vccd_lvc_clamped3_pad  user1_vccd_lvclamp_pad $PDKPATH/libs.ref/sky130_fd_io/maglef
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 922600
 box 0 -2177 17187 39593
 use sky130_ef_io__vdda_hvc_clamped_pad  user1_vdda_hvclamp_pad\[0\]
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 833400
 box 0 -407 15000 39593
 use sky130_ef_io__vdda_hvc_clamped_pad  user1_vdda_hvclamp_pad\[1\]
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 518800
 box 0 -407 15000 39593
 use sky130_ef_io__vssa_hvc_clamped_pad  user1_vssa_hvclamp_pad\[0\]
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 575600 0 1 998007
 box 0 -407 15000 39593
 use sky130_ef_io__vssa_hvc_clamped_pad  user1_vssa_hvclamp_pad\[1\]
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 430600
 box 0 -407 15000 39593
 use sky130_ef_io__vssd_lvc_clamped3_pad  user1_vssd_lvclamp_pad $PDKPATH/libs.ref/sky130_fd_io/maglef
-timestamp 1663859327
+timestamp 1666199351
 transform 0 1 678007 -1 0 474800
 box 0 -2177 17187 39593
 use sky130_ef_io__analog_pad  user2_analog_pad\[0\]
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 180000 0 1 997600
 box 0 0 15000 40000
 use sky130_ef_io__analog_pad  user2_analog_pad\[1\]
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 128600 0 1 997600
 box 0 0 15000 40000
 use sky130_ef_io__analog_pad  user2_analog_pad\[2\]
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 77200 0 1 997600
 box 0 0 15000 40000
 use sky130_ef_io__analog_pad  user2_analog_pad\[3\]
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 40000 1 0 955200
 box 0 0 15000 40000
 use sky130_ef_io__top_power_hvc  user2_analog_pad_with_clamp\[0\]
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 273600 0 1 998007
 box 0 -407 33800 39593
 use sky130_ef_io__top_power_hvc  user2_analog_pad_with_clamp\[1\]
-timestamp 1663859327
+timestamp 1666199351
 transform 1 0 221000 0 1 998007
 box 0 -407 33800 39593
 use sky130_ef_io__corner_pad  user2_corner
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 40800 1 0 997600
 box 0 0 40000 40800
 use sky130_ef_io__vccd_lvc_clamped3_pad  user2_vccd_lvclamp_pad
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 912000
 box 0 -2177 17187 39593
 use sky130_ef_io__vdda_hvc_clamped_pad  user2_vdda_hvclamp_pad
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 483000
 box 0 -407 15000 39593
 use sky130_ef_io__vssa_hvc_clamped_pad  user2_vssa_hvclamp_pad
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 827600
 box 0 -407 15000 39593
 use sky130_ef_io__vssd_lvc_clamped3_pad  user2_vssd_lvclamp_pad
-timestamp 1663859327
+timestamp 1666199351
 transform 0 -1 39593 1 0 440800
 box 0 -2177 17187 39593
 << labels >>

--- a/manifest
+++ b/manifest
@@ -5,7 +5,7 @@ cf40562ae6508f3dc5e81420e31f7b5886dc3c8f  verilog/rtl/__user_analog_project_wrap
 5f8e2d6670ce912bc209201d23430f62730e2627  verilog/rtl/__user_project_la_example.v
 cc82a78753f5f5d0a1519bd81adbcff8a4296d91  verilog/rtl/__user_project_wrapper.v
 3c8c04f53b2848dc46132cda82c614e06e56571b  verilog/rtl/buff_flash_clkrst.v
-324049b15be206b5f26225d626899d643850d31c  verilog/rtl/caravan.v
+371591b55351ff43e55a0cefeeeee34c8ac87b80  verilog/rtl/caravan.v
 06e92151b5928e3f28e30a5cde76f7dd6530ed91  verilog/rtl/caravan_netlists.v
 a3d12a2d2d3596800bec47d1266dce2399a2fcc6  verilog/rtl/caravan_openframe.v
 b532b4c6315c29fd19fe38ac221b6fc41e6f5ecb  verilog/rtl/caravan_power_routing.v

--- a/manifest
+++ b/manifest
@@ -5,7 +5,7 @@ cf40562ae6508f3dc5e81420e31f7b5886dc3c8f  verilog/rtl/__user_analog_project_wrap
 5f8e2d6670ce912bc209201d23430f62730e2627  verilog/rtl/__user_project_la_example.v
 cc82a78753f5f5d0a1519bd81adbcff8a4296d91  verilog/rtl/__user_project_wrapper.v
 3c8c04f53b2848dc46132cda82c614e06e56571b  verilog/rtl/buff_flash_clkrst.v
-2a5a008b29a1f494010e9245d56dbefd770e61f0  verilog/rtl/caravan.v
+324049b15be206b5f26225d626899d643850d31c  verilog/rtl/caravan.v
 06e92151b5928e3f28e30a5cde76f7dd6530ed91  verilog/rtl/caravan_netlists.v
 a3d12a2d2d3596800bec47d1266dce2399a2fcc6  verilog/rtl/caravan_openframe.v
 b532b4c6315c29fd19fe38ac221b6fc41e6f5ecb  verilog/rtl/caravan_power_routing.v

--- a/verilog/rtl/caravan.v
+++ b/verilog/rtl/caravan.v
@@ -168,6 +168,7 @@ module caravan (
     wire [`MPRJ_IO_PADS-`ANALOG_PADS-1:0] mprj_io_in_3v3;
     wire [`MPRJ_IO_PADS-`ANALOG_PADS-1:0] mprj_io_out;
     wire [`MPRJ_IO_PADS-`ANALOG_PADS-1:0] mprj_io_one;
+    wire [7:0] mprj_io_zero;
 
     // User Project Control (user-facing)
     // 27 GPIO bidirectional with in/out/oeb and a 3.3V copy of the input
@@ -336,8 +337,18 @@ module caravan (
     assign mgmt_io_out[6:0] = mgmt_io_out_hk[6:0];
     assign mgmt_io_oeb[34:0] = mgmt_io_oeb_hk[34:0];
 
+    /* The following are tied to ground through the zero value	*/
+    /* outputs of the closest GPIO control blocks.  Tie two 	*/
+    /* inputs to one zero value output so that the wires from	*/
+    /* the GPIOs to housekeeping don't get too long.		*/
+    assign mgmt_io_in_hk[24:14] = {mprj_io_zero[5],
+		mprj_io_zero[4], mprj_io_zero[4],
+		mprj_io_zero[3], mprj_io_zero[3],
+		mprj_io_zero[2], mprj_io_zero[2],
+		mprj_io_zero[1], mprj_io_zero[1],
+		mprj_io_zero[0], mprj_io_zero[0]};
+
     /* The following are no-connects in caravan (no associated GPIO) */
-    assign mgmt_io_in_hk[24:14] = mgmt_io_in[24:14];
     assign mgmt_io_out[24:14] = mgmt_io_out_hk[24:14];
 
     gpio_signal_buffering_alt sigbuf (
@@ -1265,7 +1276,7 @@ module caravan (
 	.mgmt_gpio_oeb(mgmt_io_oeb[1:0]),
 
         .one(mprj_io_one[1:0]),
-        .zero(),
+        .zero(mprj_io_zero[1:0]),
 
     	// Serial data chain for pad configuration
     	.serial_data_in(gpio_serial_link_1_shifted[1:0]),
@@ -1319,9 +1330,8 @@ module caravan (
 	.mgmt_gpio_out(mgmt_io_out[7:2]),
 	.mgmt_gpio_oeb(mprj_io_one[7:2]),
 
-
         .one(mprj_io_one[7:2]),
-        .zero(),
+        .zero(mprj_io_zero[7:2]),
 
     	// Serial data chain for pad configuration
     	.serial_data_in(gpio_serial_link_1_shifted[7:2]),

--- a/verilog/rtl/caravan.v
+++ b/verilog/rtl/caravan.v
@@ -1476,9 +1476,8 @@ module caravan (
 
  	.mgmt_gpio_in(mgmt_io_in[(`DIG2_TOP-3):`DIG2_BOT]),
  	.mgmt_gpio_out(mgmt_io_out[(`DIG2_TOP-3):`DIG2_BOT]),
-	.mgmt_gpio_oeb(mprj_io_one[(`MPRJ_IO_PADS_2-`ANALOG_PADS_2-4):0]),
-
-        .one(mprj_io_one[(`MPRJ_IO_PADS_2-`ANALOG_PADS_2-4):0]),
+	.mgmt_gpio_oeb(mprj_io_one[(`MPRJ_DIG_PADS-4):(`MPRJ_IO_PADS_1-`ANALOG_PADS_1)]),
+	.one(mprj_io_one[(`MPRJ_DIG_PADS-4):(`MPRJ_IO_PADS_1-`ANALOG_PADS_1)]),
         .zero(),
 
     	// Serial data chain for pad configuration


### PR DESCRIPTION
This pull request solves the issues #328, #329, and #331.  One (RTL issue) corrects the indexes of the OEB pins on the left-hand side and prevents a wiring mess at the top level.  The second one (RTL and ERC issue) ties down unconnected inputs to housekeeping.  The third one (layout issue) corrects a missing part of the porb_h wire on the right-hand side of the padframe.  All three issues are unique to the Caravan version of the chip.