### PR TITLE
gpio_signal_buffering rtl decaps

### DIFF
--- a/manifest
+++ b/manifest
@@ -26,8 +26,8 @@ ce49f9af199b5f16d2c39c417d58e5890bc7bab2  verilog/rtl/digital_pll_controller.v
 00d2c61e4f424dfce3635f96a1c1bfdeaf7d0cf8  verilog/rtl/gpio_control_block.v
 9c92ddf1391fa75ee906e452e168ca2cdd23bd18  verilog/rtl/gpio_defaults_block.v
 32d395d5936632f3c92a0de4867d6dd7cd4af1bb  verilog/rtl/gpio_logic_high.v
-095aba3128be2f6f776ddf66596249c85471cd75  verilog/rtl/gpio_signal_buffering.v
-1a7e1e050b963054f5b62784249f713c90eaaaf0  verilog/rtl/gpio_signal_buffering_alt.v
+3887ba3138be80a9ae0bb29516f4a2fbcc10713c  verilog/rtl/gpio_signal_buffering.v
+2ebc253e0c3034f09e50f76b28d8a80b8fdf0dac  verilog/rtl/gpio_signal_buffering_alt.v
 0dc5b899412a3a3a3a8ccf662bad1056d294f50b  verilog/rtl/housekeeping.v
 34c6ab585986a00216c72f2f1fea0e5a8523867b  verilog/rtl/housekeeping_spi.v
 ee3fbd794fcc6d221562147b09891e315873ac4c  verilog/rtl/mgmt_protect.v

--- a/manifest
+++ b/manifest
@@ -26,8 +26,8 @@ ce49f9af199b5f16d2c39c417d58e5890bc7bab2  verilog/rtl/digital_pll_controller.v
 00d2c61e4f424dfce3635f96a1c1bfdeaf7d0cf8  verilog/rtl/gpio_control_block.v
 9c92ddf1391fa75ee906e452e168ca2cdd23bd18  verilog/rtl/gpio_defaults_block.v
 32d395d5936632f3c92a0de4867d6dd7cd4af1bb  verilog/rtl/gpio_logic_high.v
-3887ba3138be80a9ae0bb29516f4a2fbcc10713c  verilog/rtl/gpio_signal_buffering.v
-2ebc253e0c3034f09e50f76b28d8a80b8fdf0dac  verilog/rtl/gpio_signal_buffering_alt.v
+406b6eba38e0a7e8ff561dc4e5395dbefc9c175c  verilog/rtl/gpio_signal_buffering.v
+45ea4a2d466d6d70e9e86011a62c1bd3f706ef99  verilog/rtl/gpio_signal_buffering_alt.v
 0dc5b899412a3a3a3a8ccf662bad1056d294f50b  verilog/rtl/housekeeping.v
 34c6ab585986a00216c72f2f1fea0e5a8523867b  verilog/rtl/housekeeping_spi.v
 ee3fbd794fcc6d221562147b09891e315873ac4c  verilog/rtl/mgmt_protect.v

--- a/openlane/gpio_signal_buffering/config.tcl
+++ b/openlane/gpio_signal_buffering/config.tcl
@@ -20,6 +20,7 @@ set ::env(DESIGN_NAME) gpio_signal_buffering
 set ::env(VERILOG_FILES) "\
 	$::env(DESIGN_DIR)/../../verilog/rtl/defines.v
 	$::env(DESIGN_DIR)/../../verilog/rtl/gpio_signal_buffering.v"
+set ::env(VERILOG_FILES_BLACKBOX) "$::env(DESIGN_DIR)/sky130_ef_sc_hd__decap_12-stub.v"
 
 set ::env(SYNTH_READ_BLACKBOX_LIB) 1
 set ::env(SYNTH_DEFINES) "USE_POWER_PINS"

--- a/openlane/gpio_signal_buffering/interactive.tcl
+++ b/openlane/gpio_signal_buffering/interactive.tcl
@@ -18,7 +18,11 @@ set script_dir [file dirname [file normalize [info script]]]
 set save_path $script_dir/../..
 
 # FOR LVS AND CREATING PORT LABELS
-prep -design $script_dir -tag gpio_signal_buffering_lvs -overwrite
+prep -design $script_dir -tag $::env(OPENLANE_RUN_TAG) -overwrite
+
+exec rm -rf $::env(CARAVEL_ROOT)/openlane/gpio_signal_buffering/runs/gpio_signal_buffering
+exec ln -sf $::env(CARAVEL_ROOT)/openlane/gpio_signal_buffering/runs/$::env(OPENLANE_RUN_TAG) \
+    $::env(CARAVEL_ROOT)/openlane/gpio_signal_buffering/runs/gpio_signal_buffering
 
 verilog_elaborate -log $::env(synthesis_logs)/synthesis.log
 #init_floorplan

--- a/openlane/gpio_signal_buffering/sky130_ef_sc_hd__decap_12-stub.v
+++ b/openlane/gpio_signal_buffering/sky130_ef_sc_hd__decap_12-stub.v
@@ -1,0 +1,8 @@
+module sky130_ef_sc_hd__decap_12(
+    input VPWR,
+    input VGND,
+    input VPB,
+    input VNB
+  );
+
+endmodule

--- a/openlane/gpio_signal_buffering_alt/config.tcl
+++ b/openlane/gpio_signal_buffering_alt/config.tcl
@@ -20,6 +20,7 @@ set ::env(DESIGN_NAME) gpio_signal_buffering_alt
 set ::env(VERILOG_FILES) "\
 	$::env(DESIGN_DIR)/../../verilog/rtl/defines.v
 	$::env(DESIGN_DIR)/../../verilog/rtl/gpio_signal_buffering_alt.v"
+set ::env(VERILOG_FILES_BLACKBOX) "$::env(DESIGN_DIR)/sky130_ef_sc_hd__decap_12-stub.v"
 
 set ::env(SYNTH_READ_BLACKBOX_LIB) 1
 set ::env(SYNTH_DEFINES) "USE_POWER_PINS"

--- a/openlane/gpio_signal_buffering_alt/interactive.tcl
+++ b/openlane/gpio_signal_buffering_alt/interactive.tcl
@@ -18,7 +18,12 @@ set script_dir [file dirname [file normalize [info script]]]
 set save_path $script_dir/../..
 
 # FOR LVS AND CREATING PORT LABELS
-prep -design $script_dir -tag gpio_signal_buffering_alt_lvs -overwrite
+
+prep -design $script_dir -tag $::env(OPENLANE_RUN_TAG) -overwrite
+
+exec rm -rf $::env(CARAVEL_ROOT)/openlane/gpio_signal_buffering_alt/runs/gpio_signal_buffering_alt
+exec ln -sf $::env(CARAVEL_ROOT)/openlane/gpio_signal_buffering_alt/runs/$::env(OPENLANE_RUN_TAG) \
+    $::env(CARAVEL_ROOT)/openlane/gpio_signal_buffering_alt/runs/gpio_signal_buffering_alt
 
 verilog_elaborate -log $::env(synthesis_logs)/synthesis.log
 #init_floorplan

--- a/openlane/gpio_signal_buffering_alt/sky130_ef_sc_hd__decap_12-stub.v
+++ b/openlane/gpio_signal_buffering_alt/sky130_ef_sc_hd__decap_12-stub.v
@@ -1,0 +1,8 @@
+module sky130_ef_sc_hd__decap_12(
+    input VPWR,
+    input VGND,
+    input VPB,
+    input VNB
+  );
+
+endmodule

--- a/verilog/gl/gpio_signal_buffering.v
+++ b/verilog/gl/gpio_signal_buffering.v
@@ -409,6 +409,612 @@ module gpio_signal_buffering(vccd, vssd, mgmt_io_in_unbuf, mgmt_io_out_unbuf, mg
   wire vccd;
   input vssd;
   wire vssd;
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[0]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[100]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[10]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[11]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[12]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[13]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[14]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[15]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[16]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[17]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[18]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[19]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[1]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[20]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[21]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[22]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[23]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[24]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[25]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[26]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[27]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[28]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[29]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[2]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[30]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[31]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[32]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[33]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[34]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[35]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[36]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[37]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[38]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[39]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[3]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[40]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[41]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[42]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[43]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[44]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[45]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[46]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[47]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[48]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[49]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[4]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[50]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[51]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[52]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[53]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[54]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[55]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[56]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[57]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[58]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[59]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[5]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[60]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[61]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[62]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[63]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[64]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[65]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[66]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[67]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[68]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[69]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[6]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[70]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[71]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[72]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[73]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[74]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[75]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[76]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[77]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[78]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[79]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[7]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[80]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[81]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[82]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[83]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[84]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[85]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[86]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[87]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[88]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[89]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[8]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[90]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[91]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[92]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[93]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[94]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[95]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[96]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[97]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[98]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[99]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[9]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
   sky130_fd_sc_hd__buf_8 \signal_buffers[0]  (
     .A(mgmt_io_in_unbuf[0]),
     .VGND(vssd),
@@ -1977,21 +2583,6 @@ module gpio_signal_buffering(vccd, vssd, mgmt_io_in_unbuf, mgmt_io_out_unbuf, mg
     .VPWR(vccd),
     .X(\buf_out[9] )
   );
-
-  /* NOTE:  Hand-edited to insert the decap_12 cells	*/
-  /* WARNING:  Hand-edited gate level netlist!		*/
-  /* Fortunately, decap cells are trivial so the change	*/
-  /* is pretty low-risk.				*/
-
-  sky130_ef_sc_hd__decap_12 sigbuf_decaps [100:0] (
-    .VGND(vssd),
-    .VNB(vssd),
-    .VPB(vccd),
-    .VPWR(vccd)
-  );
-
-  /* End of hand-editing */
-
   assign \buf_out[192]  = \buf_in[193] ;
   assign \buf_out[190]  = \buf_in[191] ;
   assign \buf_out[188]  = \buf_in[189] ;

--- a/verilog/gl/gpio_signal_buffering_alt.v
+++ b/verilog/gl/gpio_signal_buffering_alt.v
@@ -221,6 +221,366 @@ module gpio_signal_buffering_alt(vccd, vssd, mgmt_io_in_unbuf, mgmt_io_out_unbuf
   wire vccd;
   input vssd;
   wire vssd;
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[0]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[10]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[11]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[12]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[13]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[14]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[15]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[16]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[17]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[18]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[19]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[1]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[20]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[21]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[22]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[23]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[24]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[25]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[26]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[27]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[28]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[29]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[2]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[30]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[31]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[32]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[33]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[34]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[35]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[36]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[37]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[38]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[39]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[3]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[40]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[41]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[42]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[43]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[44]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[45]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[46]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[47]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[48]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[49]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[4]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[50]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[51]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[52]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[53]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[54]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[55]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[56]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[57]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[58]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[59]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[5]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[6]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[7]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[8]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
+  sky130_ef_sc_hd__decap_12 \sigbuf_decaps[9]  (
+    .VGND(vssd),
+    .VNB(vssd),
+    .VPB(vccd),
+    .VPWR(vccd)
+  );
   sky130_fd_sc_hd__buf_8 \signal_buffers[0]  (
     .A(mgmt_io_in_unbuf[0]),
     .VGND(vssd),
@@ -1037,21 +1397,6 @@ module gpio_signal_buffering_alt(vccd, vssd, mgmt_io_in_unbuf, mgmt_io_out_unbuf
     .VPWR(vccd),
     .X(\buf_in[10] )
   );
-
-  /* NOTE:  Hand-edited to insert the decap_12 cells    */
-  /* WARNING:  Hand-edited gate level netlist!          */
-  /* Fortunately, decap cells are trivial so the change */
-  /* is pretty low-risk.                                */
-
-  sky130_ef_sc_hd__decap_12 sigbuf_decaps [59:0] (
-    .VGND(vssd),
-    .VNB(vssd),
-    .VPB(vccd),
-    .VPWR(vccd)
-  );
-
-  /* End of hand-editing */
-
   assign \buf_in[98]  = mgmt_io_oeb_unbuf[1];
   assign \buf_in[96]  = mgmt_io_oeb_unbuf[0];
   assign \buf_in[94]  = mgmt_io_out_unbuf[19];

--- a/verilog/rtl/gpio_signal_buffering.v
+++ b/verilog/rtl/gpio_signal_buffering.v
@@ -479,7 +479,7 @@ module gpio_signal_buffering (
 	    .VPWR(vccd),
 	    .VGND(vssd),
 	    .VPB(vccd),
-	    .VNB(vssd),
+	    .VNB(vssd)
 	`endif
   );
 

--- a/verilog/rtl/gpio_signal_buffering.v
+++ b/verilog/rtl/gpio_signal_buffering.v
@@ -474,4 +474,13 @@ module gpio_signal_buffering (
     assign buf_in[195] = buf_out[194];
     assign mgmt_io_oeb_buf[2] = buf_out[195];
 
+  sky130_ef_sc_hd__decap_12 sigbuf_decaps [100:0] (
+	`ifdef USE_POWER_PINS
+	    .VPWR(vccd),
+	    .VGND(vssd),
+	    .VPB(vccd),
+	    .VNB(vssd),
+	`endif
+  );
+
 endmodule

--- a/verilog/rtl/gpio_signal_buffering_alt.v
+++ b/verilog/rtl/gpio_signal_buffering_alt.v
@@ -327,4 +327,13 @@ module gpio_signal_buffering_alt (
     assign buf_in[101] = buf_out[100];
     assign mgmt_io_oeb_buf[2] = buf_out[101];
 
+    sky130_ef_sc_hd__decap_12 sigbuf_decaps [59:0] (
+    `ifdef USE_POWER_PINS
+        .VPWR(vccd),
+        .VGND(vssd),
+        .VPB(vccd),
+        .VNB(vssd),
+    `endif
+    );
+
 endmodule

--- a/verilog/rtl/gpio_signal_buffering_alt.v
+++ b/verilog/rtl/gpio_signal_buffering_alt.v
@@ -332,7 +332,7 @@ module gpio_signal_buffering_alt (
         .VPWR(vccd),
         .VGND(vssd),
         .VPB(vccd),
-        .VNB(vssd),
+        .VNB(vssd)
     `endif
     );
 


### PR DESCRIPTION
\+ add `sky130_ef_sc_hd__decap_12` decaps in the rtl of `gpio_signal_buffering`
\+ add `sky130_ef_sc_hd__decap_12` stub file for openlane; there is no yosys-parseable verilog model for `sky130_ef_sc_hd__decap_12`
~ change config of `gpio_signal_buffering*` to add `sky130_ef_sc_hd__decap_12`
~ regenerate the gl netlist based on the above changes
~ change interactive script to generate a run directory similar to other openlane runs

need for this change:
1. The previous gl netlists of `gpio_signal_buffering*` blocks were hand-edited to insert instances of decap cells. This will generate a netlist with the decaps inserted in the rtl.
2. sta tools (such as OpenSTA) fail due to bus syntax in the netlist.

I don't think this change will affect anything functional. I have added @M0stafaRady for simulations (if needed) and @RTimothyEdwards for reviewing all the changes.