### PR TITLE
Fixes for enabling correct DEF generation.

### DIFF
--- a/mag/gpio_signal_buffering.mag
+++ b/mag/gpio_signal_buffering.mag
@@ -9991,9 +9991,9 @@ flabel metal3 40076 345792 40166 346089 0 FreeSans 400 90 0 0 vccd
 port 136 nsew ground input
 flabel metal3 40074 346985 40164 347282 0 FreeSans 400 90 0 0 vssd
 port 135 nsew power input
-flabel metal3 146226 41997 146532 42091 0 FreeSans 400 0 0 0 vccd9
+flabel metal3 146226 41997 146532 42091 0 FreeSans 400 0 0 0 vccd
 port 136 nsew power input
-flabel metal3 147432 41997 147738 42091 0 FreeSans 400 0 0 0 vssd9
+flabel metal3 147432 41997 147738 42091 0 FreeSans 400 0 0 0 vssd
 port 135 nsew ground input
 << properties >>
 string FIXED_BBOX 0 0 717600 1037600

--- a/scripts/chip_io_prep.sh
+++ b/scripts/chip_io_prep.sh
@@ -10,6 +10,7 @@
 # magic layout.
 #
 # Written by Tim Edwards for MPW-7  10/11/2022
+# Updated/fixed 11/08/2022
 #-------------------------------------------------------------------
 
 echo ${PDK_ROOT:=/usr/share/pdk} > /dev/null
@@ -17,8 +18,10 @@ echo ${PDK:=sky130A} > /dev/null
 
 # Generate DEF of chip_io
 echo "Generating DEF view of chip_io"
-magic -d OGL -rcfile ${PDK_ROOT}/${PDK}/libs.tech/magic/${PDK}.magicrc << EOF
+magic -dnull -noconsole -rcfile ${PDK_ROOT}/${PDK}/libs.tech/magic/${PDK}.magicrc << EOF
 load chip_io
+select top cell
+expand
 property flatten true
 flatten -doproperty chip_io_flat
 load chip_io_flat
@@ -28,6 +31,19 @@ select top cell
 extract do local
 extract no all
 extract all
+# Declare all signals to be SPECIALNETS
+set globals(vccd) 1
+set globals(vssd) 1
+set globals(vddio) 1
+set globals(vssio) 1
+set globals(vdda1) 1
+set globals(vssa1) 1
+set globals(vccd1) 1
+set globals(vssd1) 1
+set globals(vdda2) 1
+set globals(vssa2) 1
+set globals(vccd2) 1
+set globals(vssd2) 1
 def write chip_io
 quit -noprompt
 EOF
@@ -36,8 +52,10 @@ rm *.ext
 
 # Generate DEF of chip_io_alt
 echo "Generating DEF view of chip_io_alt"
-magic -d OGL -rcfile ${PDK_ROOT}/${PDK}/libs.tech/magic/${PDK}.magicrc << EOF
+magic -dnull -noconsole -rcfile ${PDK_ROOT}/${PDK}/libs.tech/magic/${PDK}.magicrc << EOF
 load chip_io_alt
+select top cell
+expand
 property flatten true
 flatten -doproperty chip_io_alt_flat
 load chip_io_alt_flat
@@ -47,6 +65,19 @@ select top cell
 extract do local
 extract no all
 extract all
+# Declare all signals to be SPECIALNETS
+set globals(vccd) 1
+set globals(vssd) 1
+set globals(vddio) 1
+set globals(vssio) 1
+set globals(vdda1) 1
+set globals(vssa1) 1
+set globals(vccd1) 1
+set globals(vssd1) 1
+set globals(vdda2) 1
+set globals(vssa2) 1
+set globals(vccd2) 1
+set globals(vssd2) 1
 def write chip_io_alt
 quit -noprompt
 EOF


### PR DESCRIPTION
Fixed the gpio_signal_buffering layout to change "vccd9" and "vssd9" labels to "vccd" and "vssd", which was missed earlier.  No impact other than how DEF gets written.  Also:  Fixed the script "chip_io_prep.sh", which needed to call out the names of the power supplies so that they would be written as SPECIALNETS in DEF, and also to expand the top level cell before flattening, without which routing subcell layouts won't get flattened.