### PR TITLE
Update serial configuration fsm to reset the transfer bit

### DIFF
--- a/manifest
+++ b/manifest
@@ -28,7 +28,7 @@ ce49f9af199b5f16d2c39c417d58e5890bc7bab2  verilog/rtl/digital_pll_controller.v
 32d395d5936632f3c92a0de4867d6dd7cd4af1bb  verilog/rtl/gpio_logic_high.v
 406b6eba38e0a7e8ff561dc4e5395dbefc9c175c  verilog/rtl/gpio_signal_buffering.v
 45ea4a2d466d6d70e9e86011a62c1bd3f706ef99  verilog/rtl/gpio_signal_buffering_alt.v
-0dc5b899412a3a3a3a8ccf662bad1056d294f50b  verilog/rtl/housekeeping.v
+f468ac85865e146c29368acec881382096eb417c  verilog/rtl/housekeeping.v
 34c6ab585986a00216c72f2f1fea0e5a8523867b  verilog/rtl/housekeeping_spi.v
 ee3fbd794fcc6d221562147b09891e315873ac4c  verilog/rtl/mgmt_protect.v
 3b1ff20593bc386d13f5e2cf1571f08121889957  verilog/rtl/mgmt_protect_hv.v

--- a/verilog/rtl/housekeeping.v
+++ b/verilog/rtl/housekeeping.v
@@ -354,6 +354,7 @@ wire mgmt_gpio_out_9_prebuff, mgmt_gpio_out_14_prebuff, mgmt_gpio_out_15_prebuff
     `define WBBD_SETUP3	4'h7	/* Apply address and data for byte 4 of 4 */
     `define WBBD_RW3	4'h8	/* Latch data for byte 4 of 4 */
     `define WBBD_DONE	4'h9	/* Send ACK back to wishbone */
+    `define WBBD_RESET	4'ha	/* Clock once to reset the transfer bit */
 
     assign sys_select = (wb_adr_i[31:8] == SYS_BASE_ADR[31:8]);
     assign gpio_select = (wb_adr_i[31:8] == GPIO_BASE_ADR[31:8]);
@@ -671,6 +672,7 @@ wire mgmt_gpio_out_9_prebuff, mgmt_gpio_out_14_prebuff, mgmt_gpio_out_15_prebuff
 	end else begin
 	    case (wbbd_state)
 		`WBBD_IDLE: begin
+		    wbbd_sck <= 1'b0;
 		    wbbd_busy <= 1'b0;
 		    if ((sys_select | gpio_select | spi_select) &&
 	    	    		 wb_cyc_i && wb_stb_i) begin
@@ -758,6 +760,13 @@ wire mgmt_gpio_out_9_prebuff, mgmt_gpio_out_14_prebuff, mgmt_gpio_out_15_prebuff
 		    wbbd_busy <= 1'b1;
 		    wbbd_sck <= 1'b0;
 		    wb_ack_o <= 1'b0;	// Reset for next access
+		    wbbd_write <= 1'b0;
+		    wbbd_state <= `WBBD_RESET;
+		end
+		`WBBD_RESET: begin
+		    wbbd_busy <= 1'b1;
+		    wbbd_sck <= 1'b1;
+		    wb_ack_o <= 1'b0;
 		    wbbd_write <= 1'b0;
 		    wbbd_state <= `WBBD_IDLE;
 		end


### PR DESCRIPTION
The following RTL update will not the functionality of the housekeeping it will just speed up the configuration process a little bit, since with this change the serial_xfer register won't stay 1 for too long. 
@marwaneltoukhy @kareefardi @mo-hosni housekeeping GL needs to be updated.
@M0stafaRady @kareefardi this RTL update needs to be merged into the gf repo as well