### PR TITLE
Return correct exit code for piped commands to make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,10 @@ MGMT_AREA_ROOT ?= $(shell pwd)/mgmt_core_wrapper
 # Build tasks such as make ship, make generate_fill, make set_user_id, make final run in the foreground (1) or background (0)
 FOREGROUND ?= 1
 
+# Ensure commands which are piped through tee return the correct exit code
+# to make
+SHELL=/bin/bash -o pipefail
+
 # PDK setup configs
 THREADS ?= $(shell nproc)
 STD_CELL_LIBRARY ?= sky130_fd_sc_hd


### PR DESCRIPTION
A number of commands are piped through tee (eg gen_gpio_defaults.py in make __gpio_defaults). Currently when they fail the error code is not propagated back to make.