### PR TITLE
Fix issues with port definitions

### DIFF
--- a/verilog/rtl/gpio_control_block.v
+++ b/verilog/rtl/gpio_control_block.v
@@ -77,7 +77,7 @@ module gpio_control_block #(
 
     // Serial data chain for pad configuration
     input  	 serial_data_in,
-    output 	 serial_data_out,
+    output reg   serial_data_out,
 
     // User-facing signals
     input        user_gpio_out,		// User space to pad
@@ -130,27 +130,10 @@ module gpio_control_block #(
     reg	 	gpio_ana_sel;
     reg	 	gpio_ana_pol;
 
-    /* Derived output values */
-    wire	pad_gpio_holdover;
-    wire	pad_gpio_slow_sel;
-    wire	pad_gpio_vtrip_sel;
-    wire      	pad_gpio_inenb;
-    wire       	pad_gpio_ib_mode_sel;
-    wire	pad_gpio_ana_en;
-    wire	pad_gpio_ana_sel;
-    wire	pad_gpio_ana_pol;
-    wire [2:0]  pad_gpio_dm;
-    wire        pad_gpio_outenb;
-    wire	pad_gpio_out;
-    wire	pad_gpio_in;
     wire	one_unbuf;
     wire	zero_unbuf;
-    wire	one;
-    wire	zero;
 
-    wire user_gpio_in;
     wire gpio_logic1;
-    reg serial_data_out;
 
     /* Serial shift for the above (latched) values */
     reg [PAD_CTRL_BITS-1:0] shift_register;

--- a/verilog/rtl/gpio_defaults_block.v
+++ b/verilog/rtl/gpio_defaults_block.v
@@ -34,7 +34,6 @@ module gpio_defaults_block #(
 `endif
     output [12:0] gpio_defaults
 );
-    wire [12:0] gpio_defaults;
     wire [12:0] gpio_defaults_high;
     wire [12:0] gpio_defaults_low;
 

--- a/verilog/rtl/mgmt_protect.v
+++ b/verilog/rtl/mgmt_protect.v
@@ -107,10 +107,6 @@ module mgmt_protect (
 	wire mprj_vdd_logic1;
 	wire mprj2_vdd_logic1;
 
-	wire user1_vcc_powergood;
-	wire user2_vcc_powergood;
-	wire user1_vdd_powergood;
-	wire user2_vdd_powergood;
 
 	wire [127:0] la_data_in_mprj_bar;
 	wire [2:0] user_irq_bar;

--- a/verilog/rtl/spare_logic_block.v
+++ b/verilog/rtl/spare_logic_block.v
@@ -39,17 +39,8 @@ module spare_logic_block (
 
     wire [3:0] spare_logic_nc;
 
-    wire [3:0] spare_xi;
-    wire       spare_xib;
-    wire [1:0] spare_xna;
-    wire [1:0] spare_xno;
-    wire [1:0] spare_xmx;
-    wire [1:0] spare_xfq;
-    wire [1:0] spare_xfqn;
-
     wire [26:0] spare_logic1;
     wire [26:0] spare_logic0;
-    wire [26:0] spare_xz;
 
     // Rename the logic0 outputs at the block pins.
     assign spare_xz = spare_logic0;

--- a/verilog/rtl/user_id_programming.v
+++ b/verilog/rtl/user_id_programming.v
@@ -28,7 +28,6 @@ module user_id_programming #(
 `endif
     output [31:0] mask_rev
 );
-    wire [31:0] mask_rev;
     wire [31:0] user_proj_id_high;
     wire [31:0] user_proj_id_low;
 


### PR DESCRIPTION
Caravel fails to build with recent Icarus Verilog versions because some of the port definitions are not valid.