### PR TITLE
docs(intro): fix rst link

### DIFF
--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -33,7 +33,7 @@ management SoC core, and an approximately 3000um x 3600um open project area for 
       Caravel floorplan
 
 This documentation focuses on the IO, protection and housekeeping blocks. 
-The management core SoC has its own [documentation here](https://caravel-mgmt-soc-litex.readthedocs.io/en/latest/)
+The management core SoC has its own `documentation here <https://caravel-mgmt-soc-litex.readthedocs.io/en/latest/>`_.
 
 The Caravel Github repository can be found here: https://github.com/efabless/caravel/
 


### PR DESCRIPTION
While reading [the caravel-harness docu](https://caravel-harness.readthedocs.io/en/latest/) I notice that one link was formated apparantly for markdown but not rst:

<img width="739" alt="Screen Shot 2023-02-19 at 01 23 28" src="https://user-images.githubusercontent.com/42791/219879572-cfd2a880-fd3f-4223-9192-0728806d654e.png">

This PR fixes this.