### PR TITLE
Modified the verilog/rtl/openframe_netlists.v.

### DIFF
--- a/manifest
+++ b/manifest
@@ -47,7 +47,7 @@ c96ba94e5779ea6afe452d89632eaada73e26aab  verilog/rtl/mprj_io.v
 e0c6ead5e35c1ba01d923c482e953c2af9691524  verilog/rtl/mprj_io_buffer.v
 3baffde4788f01e2ff0e5cd83020a76bd63ef7d7  verilog/rtl/mprj_logic_high.v
 5287821a0ed1994850a978ef0cd024fac51fb6e8  verilog/rtl/open_source.v
-33c8fc54298e5425875aaab8c139074ec7d0e9e9  verilog/rtl/openframe_netlists.v
+189532aff9e5e2ebbd99befd05cbf50e948b14af  verilog/rtl/openframe_netlists.v
 4edbfd0ad80b69a799a399ffc717b560fcae615b  verilog/rtl/pads.v
 669d16642d5dd5f6824812754db20db98c9fe17b  verilog/rtl/ring_osc2x13.v
 739ca5ed63a513d2e4c9bf3ecfad32d9fa527518  verilog/rtl/simple_por.v

--- a/verilog/rtl/openframe_netlists.v
+++ b/verilog/rtl/openframe_netlists.v
@@ -45,11 +45,11 @@
     `endif 
 
     `ifdef GL
-	`include "gl/user_id_programming.v"
-	`include "gl/chip_io_openframe.v"
+	`include "user_id_programming.v"
+	`include "chip_io_openframe.v"
 	`include "gl/constant_block.v"
 	`include "gl/xres_buf.v"
-	`include "gl/caravel_openframe.v"
+	`include "caravel_openframe.v"
     `else
 	`include "user_id_programming.v"
 	`include "chip_io_openframe.v"


### PR DESCRIPTION
This file indicates which verilog files to include for openframe simulations.  Noted that there were references in the file to GL versions of user_id_programming.v, chip_io_openframe.v, and caravel_openframe.v.  All three of these are already structural verilog and do not have versions in the gl/ directory.