### PR TITLE
Corrected the set_user_id.py script to put the bits in the correct direction.

### DIFF
--- a/manifest
+++ b/manifest
@@ -54,6 +54,6 @@ b53c154e6acaf44e858c936c8027d0229608676e  verilog/rtl/pads.v
 b9d6114a5067a04dd59cdd46fb988591c16743ce  verilog/rtl/spare_logic_block.v
 9178c87e3d5196fd3e6abae6fc310e1b663ade0e  verilog/rtl/toplevel_cocotb.v
 8f0bec01c914efe790a09ffe62bbfe0781069e35  verilog/rtl/xres_buf.v
-256190717faa72005cf7656d8443c4c0693b3f78  scripts/set_user_id.py
+ea0c5e1981b50a6a417c94ea2b807bb8b73da030  scripts/set_user_id.py
 731116709a44d13225170acc83cd34ff9e00fa39  scripts/generate_fill.py
 dff8adfb05bedf96f86e16a18ce3cd5818d6fb78  scripts/compositor.py

--- a/scripts/set_user_id.py
+++ b/scripts/set_user_id.py
@@ -170,7 +170,7 @@ if __name__ == '__main__':
 
             try:
                 user_id_int = int('0x' + user_id_value, 0)
-                user_id_bits = '{0:032b}'.format(user_id_int)
+                user_id_bits = '{0:032b}'.format(user_id_int)[::-1]
             except:
                 print('Error:  Cannot parse user ID "' + user_id_value + '" as an 8-digit hex number.')
                 sys.exit(1)


### PR DESCRIPTION
Corrected the set_user_id.py script to put the bits in the correct direction when casting from an integer to a binary string.  This is the same correction that was made to caravel-gf180mcu some time ago.  Thanks to Mitch Bailey for finding and reporting the issue.  This solves issue #516.