### PR TITLE
Remove PDK build targets from Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /mgmt_core_wrapper/*
 gds/*.gds
+/venv

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+volare
+rst_include


### PR DESCRIPTION
As discussed--

- pdk can now only be fetched with volare -- users who want to build their own PDK should know what they're doing
- volare, rst_include now share a venv
- venv no longer needlessly recreated every single time volare is installed
- venv added to gitignore
- check-python reimplemented